### PR TITLE
Enable strategies written directly in Python as an alt to engines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ pip install -r requirements.txt
 - Place your engine(s) in the `engine.dir` directory
 - In `config.yml`, enter the binary name as the `engine.name` field (In Windows you may need to type a name with ".exe", like "lczero.exe")
 - Leave the `weights` field empty or see LeelaChessZero section for Neural Nets
+- You can also write a direct strategy (a Python function from `chess.Board` to `chess.Move`) instead of a UCI or XBoard compliant engine. See the[strategies.py](strategies.py) file for a tiny example.
 
 
 ## Lichess Upgrade to Bot Account

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import yaml
 import os
 import os.path
+from strategies import strategies
 
 def load_config(config_file):
     with open(config_file) as stream:
@@ -35,12 +36,16 @@ def load_config(config_file):
         if not os.path.isdir(CONFIG["engine"]["dir"]):
             raise Exception("Your engine directory `{}` is not a directory.")
 
-        engine = os.path.join(CONFIG["engine"]["dir"], CONFIG["engine"]["name"])
+        if CONFIG["engine"]["protocol"] == "strategy":
+            if CONFIG["engine"]["name"] not in strategies:
+                raise Exception("The strategy %s does not exist." % CONFIG["engine"]["name"])
+        else:
+            engine = os.path.join(CONFIG["engine"]["dir"], CONFIG["engine"]["name"])
 
-        if not os.path.isfile(engine):
-            raise Exception("The engine %s file does not exist." % engine)
+            if not os.path.isfile(engine):
+                raise Exception("The engine %s file does not exist." % engine)
 
-        if not os.access(engine, os.X_OK):
-            raise Exception("The engine %s doesn't have execute (x) permission. Try: chmod +x %s" % (engine, engine))
+            if not os.access(engine, os.X_OK):
+                raise Exception("The engine %s doesn't have execute (x) permission. Try: chmod +x %s" % (engine, engine))
 
     return CONFIG

--- a/config.yml.default
+++ b/config.yml.default
@@ -3,8 +3,8 @@ url: "https://lichess.org/"  # lichess base URL
 
 engine:                      # engine settings
   dir: "./engines/"          # dir containing engines, relative to this project
-  name: "engine_name"        # binary name of the engine to use
-  protocol: "uci"            # "uci" or "xboard"
+  name: "engine_name"        # (binary) name of the engine to use
+  protocol: "uci"            # "uci" or "xboard" or "strategy"
   polyglot:
     enabled: false           # activate polyglot book
     book:

--- a/strategies.py
+++ b/strategies.py
@@ -1,0 +1,11 @@
+import chess
+import random
+
+def random_strategy(board):
+    move = random.choice(list(board.legal_moves))
+    return move.uci()
+
+# Add your strategies to this dictionary.
+# Key: name
+# Value: function from chess.Board to chess.Move
+strategies = {'random':random_strategy}


### PR DESCRIPTION
I thought it convenient, for prototyping, to be able to transform any strategy (represented as a Python function from board to move) into a Lichess bot.

WDYT?

Thanks.