### PR TITLE
Xboard fixes

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -185,12 +185,14 @@ class XBoardEngine(EngineWrapper):
             self.engine.usermove(board.peek())
         except IndexError:
             self.engine.setboard(board)
+
+        # XBoard engines expect time in units of 1/100 seconds.
         if board.turn == chess.WHITE:
-            self.engine.time(wtime)
-            self.engine.otim(btime)
+            self.engine.time(wtime//10)
+            self.engine.otim(btime//10)
         else:
-            self.engine.time(btime)
-            self.engine.otim(wtime)
+            self.engine.time(btime//10)
+            self.engine.otim(wtime//10)
         return self.engine.go()
 
     def print_stats(self):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -188,11 +188,11 @@ class XBoardEngine(EngineWrapper):
 
         # XBoard engines expect time in units of 1/100 seconds.
         if board.turn == chess.WHITE:
-            self.engine.time(wtime//10)
-            self.engine.otim(btime//10)
+            self.engine.time(wtime // 10)
+            self.engine.otim(btime // 10)
         else:
-            self.engine.time(btime//10)
-            self.engine.otim(wtime//10)
+            self.engine.time(btime // 10)
+            self.engine.otim(wtime // 10)
         return self.engine.go()
 
     def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -195,6 +195,9 @@ class XBoardEngine(EngineWrapper):
             self.engine.otim(wtime//10)
         return self.engine.go()
 
+    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):
+        return self.search(board, wtime, btime, winc, binc), None
+
     def print_stats(self):
         self.print_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
 


### PR DESCRIPTION
These commits make Xboard engines usable again with lichess-bot by fixing two problems:

1. Clock times are sent in centiseconds (1/100 seconds) to Xboard engines according to the standard.
2. The XBoardEngine class in engine_wrapper.py did not implement the search_with_ponder() method.