### PR TITLE
Clock resent to Xboard engines after first move

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -167,15 +167,19 @@ class XBoardEngine(EngineWrapper):
                     pass
 
     def set_time_control(self, game):
-        minutes = game.clock_initial / 1000 / 60
-        seconds = game.clock_initial / 1000 % 60
-        inc = game.clock_increment / 1000
-        self.engine.level(0, minutes, seconds, inc)
+        self.minutes = game.clock_initial / 1000 / 60
+        self.seconds = game.clock_initial / 1000 % 60
+        self.inc = game.clock_increment / 1000
+        self.send_time()
+
+    def send_time(self):
+        self.engine.level(0, self.minutes, self.seconds, self.inc)
 
     def first_search(self, board, movetime):
         self.engine.setboard(board)
         self.engine.st(movetime / 1000)
         bestmove = self.engine.go()
+        self.send_time()
 
         return bestmove
 


### PR DESCRIPTION
Since the first move uses a 10-second time limit ("st 10"), the clock
specification ("level") needs to be sent a second time after the first
move to let Xboard engines know the actual clock being used.

This is different than UCI, which sends the full clock specification on
every move. The Xboard protocol only sends the increment and moves
per clock reset once at the beginning of the game. That is, if I'm reading
the Xboard protocol correctly, every reception of "level" or "st" should
replace the engine's previous internal clock.