### PR TITLE
Handle extra messages from lichess when game ends

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -388,6 +388,8 @@ def update_board(board, move):
     uci_move = chess.Move.from_uci(move)
     if board.is_legal(uci_move):
         board.push(uci_move)
+    else:
+        logger.debug('Ignoring illegal move {} on board {}'.format(move, board.fen()))
     return board
 
 def intro():

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -386,7 +386,8 @@ def is_engine_move(game, moves):
 
 def update_board(board, move):
     uci_move = chess.Move.from_uci(move)
-    board.push(uci_move)
+    if board.is_legal(uci_move):
+        board.push(uci_move)
     return board
 
 def intro():


### PR DESCRIPTION
When the winning (or possibly just game ending) move is made in a game,
lichess sends two JSON packets for that move. For example, here are the
last JSON packets received (gathered by adding `logger.info(str(upd))`
after line 208 in lichess-bot.py):

    {'type': 'gameState',
     'moves': 'b2b3 e7e5 a2a3 f8c5 h2h4 d8f6 e2e4',
     'wtime': 299800,
     'btime': 295210,
     'winc': 0,
     'binc': 0,
     'wdraw': False,
     'bdraw': False,
     'status': 'started'}

    {'type': 'gameState',
     'moves': 'b2b3 e7e5 a2a3 f8c5 h2h4 d8f6 e2e4 f6f2',
     'wtime': 299800,
     'btime': 293610,
     'winc': 0,
     'binc': 0,
     'wdraw': False,
     'bdraw': False,
     'status': 'mate'}

    {'type': 'gameState',
     'moves': 'b2b3 e7e5 a2a3 f8c5 h2h4 d8f6 e2e4 f6f2',
     'wtime': 299800,
     'btime': 293610,
     'winc': 0,
     'binc': 0,
     'wdraw': False,
     'bdraw': False,
     'status': 'mate',
     'winner': 'black'}

The first JSON packet is the last midgame move (notice that the `status`
is `started`.

The second JSON packet contains the game-winning move and the status has
changed to `mate`.

The third JSON packet only has the addition of `'winner': 'black'`. More
importantly, they both contain the same move lists, so duplicate move
are added when `board = update_board(board, moves[-1])` (line 215) is
called.

This commit checks that a move is legal before pushing it onto the
board's move stack inside `update_board()`.

Relevant Issues:
Fixes #202
Fixes #214