### PR TITLE
Stop bots when drawn by 3-fold or 50-move rule

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -170,7 +170,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     break
     else:
         moves = game.state["moves"].split()
-        if not board.is_game_over() and is_engine_move(game, moves):
+        if not board.is_game_over(claim_draw=True) and is_engine_move(game, moves):
             book_move = None
             best_move = None
             ponder_move = None
@@ -213,7 +213,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                 game.state = upd
                 moves = upd["moves"].split()
                 board = update_board(board, moves[-1])
-                if not board.is_game_over() and is_engine_move(game, moves):
+                if not board.is_game_over(claim_draw=True) and is_engine_move(game, moves):
                     if config.get("fake_think_time") and len(moves) > 9:
                         delay = min(game.clock_initial, game.my_remaining_seconds()) * 0.015
                         accel = 1 - max(0, min(100, len(moves) - 20)) / 150


### PR DESCRIPTION
The method `board.is_game_over()` does not return True for games drawn
by the threefold repetition rule or the 50-move rule unless the kwargs
parameter `claim_draw` is set to True. Since lichess does end these games
without needing the players to claim it, lichess-bot should do the same.