### PR TITLE
Fix problems with python-chess draw claims: Fixes #221

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -171,7 +171,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     break
     else:
         moves = game.state["moves"].split()
-        if not board.is_game_over(claim_draw=True) and is_engine_move(game, moves):
+        if not is_game_over(game) and is_engine_move(game, moves):
             book_move = None
             best_move = None
             ponder_move = None
@@ -214,7 +214,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                 game.state = upd
                 moves = upd["moves"].split()
                 board = update_board(board, moves[-1])
-                if not board.is_game_over(claim_draw=True) and is_engine_move(game, moves):
+                if not is_game_over(game) and is_engine_move(game, moves):
                     if config.get("fake_think_time") and len(moves) > 9:
                         delay = min(game.clock_initial, game.my_remaining_seconds()) * 0.015
                         accel = 1 - max(0, min(100, len(moves) - 20)) / 150
@@ -383,6 +383,10 @@ def is_white_to_move(game, moves):
 
 def is_engine_move(game, moves):
     return game.is_white == is_white_to_move(game, moves)
+
+
+def is_game_over(game):
+    return game.state["status"] != "started"
 
 
 def update_board(board, move):


### PR DESCRIPTION
In the python-chess library used by lichess-bot,

    board.game_is_over(claim_draw=True)

returns True not only according to the 50-move rule or the 3-fold rule,
but also if there is a legal move on the current that would activate
these rules. Although this is proper according to FIDE rules, lichess
does not have the facility for players (whether bot or human) to make
these pre-move claims. Lichess will not recognize a rule-based draw
until the actual move is made.

In this commit, instead of using the local board to determine if the
game is over, the engine is told to keep playing until lichess says the
game is over. This check is done by the new function `is_game_over()`
that checks whether the `status` field in the JSON message is set to
`started`.