### PR TITLE
Coding style fixes from flake8

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@ import yaml
 import os
 import os.path
 
+
 def load_config(config_file):
     with open(config_file) as stream:
         try:
@@ -10,7 +11,7 @@ def load_config(config_file):
             print("There appears to be a syntax problem with your config.yml")
             raise e
 
-        #[section, type, error message]
+        # [section, type, error message]
         sections = [["token", str, "Section `token` must be a string wrapped in quotes."],
                     ["url", str, "Section `url` must be a string wrapped in quotes."],
                     ["engine", dict, "Section `engine` must be a dictionary with indented keys followed by colons.."],

--- a/conversation.py
+++ b/conversation.py
@@ -1,4 +1,4 @@
-class Conversation():
+class Conversation:
     def __init__(self, game, engine, xhr, version, challenge_queue):
         self.game = game
         self.engine = engine
@@ -40,7 +40,7 @@ class Conversation():
         self.xhr.chat(self.game.id, line.room, reply)
 
 
-class ChatLine():
+class ChatLine:
     def __init__(self, json):
         self.room = json.get("room")
         self.username = json.get("username")

--- a/conversation.py
+++ b/conversation.py
@@ -1,5 +1,3 @@
-from time import time
-
 class Conversation():
     def __init__(self, game, engine, xhr, version, challenge_queue):
         self.game = game

--- a/conversation.py
+++ b/conversation.py
@@ -12,7 +12,6 @@ class Conversation:
         print("*** {} [{}] {}: {}".format(self.game.url(), line.room, line.username, line.text.encode("utf-8")))
         if (line.text[0] == self.command_prefix):
             self.command(line, game, line.text[1:].lower())
-        pass
 
     def command(self, line, game, cmd):
         if cmd == "commands" or cmd == "help":

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -25,6 +25,21 @@ def create_engine(config, board):
     return UCIEngine(board, commands, cfg.get("uci_options", {}) or {}, silence_stderr)
 
 
+def print_handler_stats(info, stats):
+    for stat in stats:
+        if stat in info:
+            print("    {}: {}".format(stat, info[stat]))
+
+
+def get_handler_stats(info, stats):
+    stats_str = []
+    for stat in stats:
+        if stat in info:
+            stats_str.append("{}: {}".format(stat, info[stat]))
+
+    return stats_str
+
+
 class EngineWrapper:
     def __init__(self, board, commands, options=None, silence_stderr=False):
         pass
@@ -49,19 +64,6 @@ class EngineWrapper:
 
     def quit(self):
         self.engine.quit()
-
-    def print_handler_stats(self, info, stats):
-        for stat in stats:
-            if stat in info:
-                print("    {}: {}".format(stat, info[stat]))
-
-    def get_handler_stats(self, info, stats):
-        stats_str = []
-        for stat in stats:
-            if stat in info:
-                stats_str.append("{}: {}".format(stat, info[stat]))
-
-        return stats_str
 
 
 class UCIEngine(EngineWrapper):
@@ -118,10 +120,10 @@ class UCIEngine(EngineWrapper):
         self.engine.stop()
 
     def print_stats(self):
-        self.print_handler_stats(self.engine.info_handlers[0].info, ["string", "depth", "nps", "nodes", "score"])
+        print_handler_stats(self.engine.info_handlers[0].info, ["string", "depth", "nps", "nodes", "score"])
 
     def get_stats(self):
-        return self.get_handler_stats(self.engine.info_handlers[0].info, ["depth", "nps", "nodes", "score"])
+        return get_handler_stats(self.engine.info_handlers[0].info, ["depth", "nps", "nodes", "score"])
 
     def get_opponent_info(self, game):
         name = game.opponent.name
@@ -220,10 +222,10 @@ class XBoardEngine(EngineWrapper):
         return self.search(board, wtime, btime, winc, binc), None
 
     def print_stats(self):
-        self.print_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
+        print_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
 
     def get_stats(self):
-        return self.get_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
+        return get_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
 
     def name(self):
         try:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -26,7 +26,6 @@ def create_engine(config, board):
 
 
 class EngineWrapper:
-
     def __init__(self, board, commands, options=None, silence_stderr=False):
         pass
 
@@ -66,7 +65,6 @@ class EngineWrapper:
 
 
 class UCIEngine(EngineWrapper):
-
     def __init__(self, board, commands, options, silence_stderr=False):
         commands = commands[0] if len(commands) == 1 else commands
         self.go_commands = options.get("go_commands", {})
@@ -135,7 +133,6 @@ class UCIEngine(EngineWrapper):
 
 
 class XBoardEngine(EngineWrapper):
-
     def __init__(self, board, commands, options=None, silence_stderr=False):
         commands = commands[0] if len(commands) == 1 else commands
         self.engine = chess.xboard.popen_engine(commands, stderr=subprocess.DEVNULL if silence_stderr else None)

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -5,6 +5,7 @@ import chess.uci
 import backoff
 import subprocess
 
+
 @backoff.on_exception(backoff.expo, BaseException, max_time=120)
 def create_engine(config, board):
     cfg = config["engine"]
@@ -70,7 +71,7 @@ class UCIEngine(EngineWrapper):
         commands = commands[0] if len(commands) == 1 else commands
         self.go_commands = options.get("go_commands", {})
 
-        self.engine = chess.uci.popen_engine(commands, stderr = subprocess.DEVNULL if silence_stderr else None)
+        self.engine = chess.uci.popen_engine(commands, stderr=subprocess.DEVNULL if silence_stderr else None)
         self.engine.uci()
 
         if options:
@@ -84,7 +85,6 @@ class UCIEngine(EngineWrapper):
 
         info_handler = chess.uci.InfoHandler()
         self.engine.info_handlers.append(info_handler)
-
 
     def first_search(self, board, movetime):
         self.engine.position(board)
@@ -100,7 +100,7 @@ class UCIEngine(EngineWrapper):
             binc=binc,
             ponder=ponder
         )
-        return ( best_move , ponder_move )
+        return (best_move, ponder_move)
 
     def search(self, board, wtime, btime, winc, binc):
         self.engine.position(board)
@@ -116,14 +116,11 @@ class UCIEngine(EngineWrapper):
         )
         return best_move
 
-
     def stop(self):
         self.engine.stop()
 
-
     def print_stats(self):
         self.print_handler_stats(self.engine.info_handlers[0].info, ["string", "depth", "nps", "nodes", "score"])
-
 
     def get_stats(self):
         return self.get_handler_stats(self.engine.info_handlers[0].info, ["depth", "nps", "nodes", "score"])
@@ -136,11 +133,12 @@ class UCIEngine(EngineWrapper):
             player_type = "computer" if title == "BOT" else "human"
             self.engine.setoption({"UCI_Opponent": "{} {} {} {}".format(title, rating, player_type, name)})
 
+
 class XBoardEngine(EngineWrapper):
 
     def __init__(self, board, commands, options=None, silence_stderr=False):
         commands = commands[0] if len(commands) == 1 else commands
-        self.engine = chess.xboard.popen_engine(commands, stderr = subprocess.DEVNULL if silence_stderr else None)
+        self.engine = chess.xboard.popen_engine(commands, stderr=subprocess.DEVNULL if silence_stderr else None)
 
         self.engine.xboard()
 
@@ -229,7 +227,6 @@ class XBoardEngine(EngineWrapper):
 
     def get_stats(self):
         return self.get_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
-
 
     def name(self):
         try:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -231,7 +231,7 @@ class XBoardEngine(EngineWrapper):
     def name(self):
         try:
             return self.engine.features.get("myname")
-        except:
+        except Exception:
             return None
 
     def get_opponent_info(self, game):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -34,15 +34,19 @@ __version__ = "1.1.5"
 
 terminated = False
 
+
 def signal_handler(signal, frame):
     global terminated
     logger.debug("Recieved SIGINT. Terminating client.")
     terminated = True
 
+
 signal.signal(signal.SIGINT, signal_handler)
+
 
 def is_final(exception):
     return isinstance(exception, HTTPError) and exception.response.status_code < 500
+
 
 def upgrade_account(li):
     if li.upgrade_to_bot_account() is None:
@@ -50,6 +54,7 @@ def upgrade_account(li):
 
     logger.info("Succesfully upgraded to Bot Account!")
     return True
+
 
 def watch_control_stream(control_queue, li):
     while not terminated:
@@ -65,6 +70,7 @@ def watch_control_stream(control_queue, li):
         except:
             pass
 
+
 def start(li, user_profile, engine_factory, config):
     challenge_config = config["challenge"]
     max_games = challenge_config.get("concurrency", 1)
@@ -77,7 +83,7 @@ def start(li, user_profile, engine_factory, config):
     busy_processes = 0
     queued_processes = 0
 
-    with logging_pool.LoggingPool(max_games+1) as pool:
+    with logging_pool.LoggingPool(max_games + 1) as pool:
         while not terminated:
             event = control_queue.get()
             if event["type"] == "terminated":
@@ -108,7 +114,7 @@ def start(li, user_profile, engine_factory, config):
                 logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
                 game_id = event["game"]["id"]
                 pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue])
-            while ((queued_processes + busy_processes) < max_games and challenge_queue): # keep processing the queue until empty or max_games is reached
+            while ((queued_processes + busy_processes) < max_games and challenge_queue):  # keep processing the queue until empty or max_games is reached
                 chlng = challenge_queue.pop(0)
                 try:
                     logger.info("    Accept {}".format(chlng))
@@ -116,7 +122,7 @@ def start(li, user_profile, engine_factory, config):
                     response = li.accept_challenge(chlng.id)
                     logger.info("--- Process Queue. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
                 except (HTTPError, ReadTimeout) as exception:
-                    if isinstance(exception, HTTPError) and exception.response.status_code == 404: # ignore missing challenge
+                    if isinstance(exception, HTTPError) and exception.response.status_code == 404:  # ignore missing challenge
                         logger.info("    Skip missing {}".format(chlng))
                     queued_processes -= 1
 
@@ -124,14 +130,16 @@ def start(li, user_profile, engine_factory, config):
     control_stream.terminate()
     control_stream.join()
 
+
 ponder_results = {}
+
 
 @backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)
 def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue):
     response = li.get_game_stream(game_id)
     lines = response.iter_lines()
 
-    #Initial response of stream will be the full game info. Store it
+    # Initial response of stream will be the full game info. Store it
     initial_state = json.loads(next(lines).decode('utf-8'))
     game = model.Game(initial_state, user_profile["username"], li.baseUrl, config.get("abort_time", 20))
     board = setup_board(game)
@@ -152,10 +160,11 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     deferredFirstMove = False
 
     ponder_uci = None
+
     def ponder_thread_func(game, engine, board, wtime, btime, winc, binc):
-        global ponder_results        
-        best_move , ponder_move = engine.search_with_ponder(board, wtime, btime, winc, binc, True)
-        ponder_results[game.id] = ( best_move , ponder_move )
+        global ponder_results
+        best_move, ponder_move = engine.search_with_ponder(board, wtime, btime, winc, binc, True)
+        ponder_results[game.id] = (best_move, ponder_move)
 
     engine.set_time_control(game)
 
@@ -167,7 +176,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                         deferredFirstMove = True
                 break
             except (HTTPError) as exception:
-                if exception.response.status_code == 400: # fallthrough
+                if exception.response.status_code == 400:  # fallthrough
                     break
     else:
         moves = game.state["moves"].split()
@@ -185,7 +194,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                 book_move = get_book_move(board, book_cfg)
             if book_move == None:
                 logger.info("Searching for wtime {} btime {}".format(wtime, btime))
-                best_move , ponder_move = engine.search_with_ponder(board, wtime, btime, game.state["winc"], game.state["binc"])
+                best_move, ponder_move = engine.search_with_ponder(board, wtime, btime, game.state["winc"], game.state["binc"])
                 engine.print_stats()
             else:
                 best_move = book_move
@@ -196,7 +205,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                 ponder_board.push(ponder_move)
                 ponder_uci = ponder_move.uci()
                 logger.info("Pondering for wtime {} btime {}".format(wtime, btime))
-                ponder_thread = threading.Thread(target = ponder_thread_func, args = (game, engine, ponder_board, wtime, btime, game.state["winc"], game.state["binc"]))
+                ponder_thread = threading.Thread(target=ponder_thread_func, args=(game, engine, ponder_board, wtime, btime, game.state["winc"], game.state["binc"]))
                 ponder_thread.start()
             li.make_move(game.id, best_move)
 
@@ -230,7 +239,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                             engine.engine.ponderhit()
                             ponder_thread.join()
                             ponder_thread = None
-                            best_move , ponder_move = ponder_results[game.id]
+                            best_move, ponder_move = ponder_results[game.id]
                             engine.print_stats()
                         else:
                             engine.engine.stop()
@@ -251,7 +260,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                         if best_move == None:
                             if book_move == None:
                                 logger.info("Searching for wtime {} btime {}".format(wtime, btime))
-                                best_move , ponder_move = engine.search_with_ponder(board, wtime, btime, upd["winc"], upd["binc"])
+                                best_move, ponder_move = engine.search_with_ponder(board, wtime, btime, upd["winc"], upd["binc"])
                                 engine.print_stats()
                             else:
                                 best_move = book_move
@@ -266,7 +275,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                             ponder_board.push(ponder_move)
                             ponder_uci = ponder_move.uci()
                             logger.info("Pondering for wtime {} btime {}".format(wtime, btime))
-                            ponder_thread = threading.Thread(target = ponder_thread_func, args = (game, engine, ponder_board, wtime, btime, upd["winc"], upd["binc"]))
+                            ponder_thread = threading.Thread(target=ponder_thread_func, args=(game, engine, ponder_board, wtime, btime, upd["winc"], upd["binc"]))
                             ponder_thread.start()
                         li.make_move(game.id, best_move)
                     else:
@@ -397,6 +406,7 @@ def update_board(board, move):
         logger.debug('Ignoring illegal move {} on board {}'.format(move, board.fen()))
     return board
 
+
 def intro():
     return r"""
     .   _/|
@@ -405,6 +415,7 @@ def intro():
     .  //__\
     .  )___(   Play on Lichess with a bot
     """ % __version__
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Play on Lichess with a bot')

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -117,7 +117,7 @@ def start(li, user_profile, engine_factory, config):
                 try:
                     logger.info("    Accept {}".format(chlng))
                     queued_processes += 1
-                    response = li.accept_challenge(chlng.id)
+                    li.accept_challenge(chlng.id)
                     logger.info("--- Process Queue. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
                 except (HTTPError, ReadTimeout) as exception:
                     if isinstance(exception, HTTPError) and exception.response.status_code == 404:  # ignore missing challenge
@@ -294,7 +294,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     if game.is_abortable():
                         li.abort(game.id)
                     break
-        except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, ProtocolError) as e:
+        except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, ProtocolError):
             ongoing_games = li.get_ongoing_games()
             game_over = True
             for ongoing_game in ongoing_games:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -429,7 +429,7 @@ if __name__ == "__main__":
     is_bot = user_profile.get("title") == "BOT"
     logger.info("Welcome {}!".format(username))
 
-    if args.u is True and is_bot is False:
+    if args.u and not is_bot:
         is_bot = upgrade_account(li)
 
     if is_bot:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -295,13 +295,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                         li.abort(game.id)
                     break
         except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, ProtocolError):
-            ongoing_games = li.get_ongoing_games()
-            game_over = True
-            for ongoing_game in ongoing_games:
-                if ongoing_game["gameId"] == game.id:
-                    game_over = False
-                    break
-            if not game_over:
+            if game.id in (ongoing_game["gameId"] for ongoing_game in li.get_ongoing_games()):
                 continue
             else:
                 break

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -8,10 +8,8 @@ import json
 import lichess
 import logging
 import multiprocessing
-import traceback
 import logging_pool
 import signal
-import sys
 import time
 import backoff
 import threading

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -67,7 +67,7 @@ def watch_control_stream(control_queue, li):
                     control_queue.put_nowait(event)
                 else:
                     control_queue.put_nowait({"type": "ping"})
-        except:
+        except Exception:
             pass
 
 
@@ -103,7 +103,7 @@ def start(li, user_profile, engine_factory, config):
                     try:
                         li.decline_challenge(chlng.id)
                         logger.info("    Decline {}".format(chlng))
-                    except:
+                    except Exception:
                         pass
             elif event["type"] == "gameStart":
                 if queued_processes <= 0:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -190,14 +190,14 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                 btime = max(0, btime - move_overhead)
             if polyglot_cfg.get("enabled") and len(moves) <= polyglot_cfg.get("max_depth", 8) * 2 - 1:
                 book_move = get_book_move(board, book_cfg)
-            if book_move == None:
+            if book_move is None:
                 logger.info("Searching for wtime {} btime {}".format(wtime, btime))
                 best_move, ponder_move = engine.search_with_ponder(board, wtime, btime, game.state["winc"], game.state["binc"])
                 engine.print_stats()
             else:
                 best_move = book_move
 
-            if is_uci_ponder and not ( ponder_move is None ):
+            if is_uci_ponder and ponder_move is not None:
                 ponder_board = board.copy()
                 ponder_board.push(best_move)
                 ponder_board.push(ponder_move)
@@ -231,7 +231,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     book_move = None
                     best_move = None
                     ponder_move = None
-                    if not ( ponder_thread is None ):
+                    if ponder_thread is not None:
                         move_uci = moves[-1]
                         if ponder_uci == move_uci:
                             engine.engine.ponderhit()
@@ -255,19 +255,19 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     if not deferredFirstMove:
                         if polyglot_cfg.get("enabled") and len(moves) <= polyglot_cfg.get("max_depth", 8) * 2 - 1:
                             book_move = get_book_move(board, book_cfg)
-                        if best_move == None:
-                            if book_move == None:
+                        if best_move is None:
+                            if book_move is None:
                                 logger.info("Searching for wtime {} btime {}".format(wtime, btime))
                                 best_move, ponder_move = engine.search_with_ponder(board, wtime, btime, upd["winc"], upd["binc"])
                                 engine.print_stats()
                             else:
                                 best_move = book_move
                         else:
-                            if not ( book_move == None ):
+                            if book_move is not None:
                                 best_move = book_move
                                 ponder_move = None
 
-                        if is_uci_ponder and not ( ponder_move is None ):
+                        if is_uci_ponder and ponder_move is not None:
                             ponder_board = board.copy()
                             ponder_board.push(best_move)
                             ponder_board.push(ponder_move)
@@ -309,7 +309,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     logger.info("--- {} Game over".format(game.url()))
     engine.engine.stop()
     engine.quit()
-    if not ( ponder_thread is None ):
+    if ponder_thread is not None:
         ponder_thread.join()
         ponder_thread = None
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -173,7 +173,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     if not play_first_move(game, engine, board, li):
                         deferredFirstMove = True
                 break
-            except (HTTPError) as exception:
+            except HTTPError as exception:
                 if exception.response.status_code == 400:  # fallthrough
                     break
     else:
@@ -210,7 +210,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     while not terminated:
         try:
             binary_chunk = next(lines)
-        except(StopIteration):
+        except StopIteration:
             break
         try:
             upd = json.loads(binary_chunk.decode('utf-8')) if binary_chunk else None

--- a/lichess.py
+++ b/lichess.py
@@ -29,7 +29,6 @@ ENDPOINTS = {
 
 # docs: https://lichess.org/api
 class Lichess:
-
     def __init__(self, token, url, version):
         self.version = version
         self.header = {

--- a/lichess.py
+++ b/lichess.py
@@ -26,6 +26,7 @@ ENDPOINTS = {
     "resign": "/api/bot/game/{}/resign"
 }
 
+
 # docs: https://lichess.org/api
 class Lichess():
 
@@ -43,10 +44,10 @@ class Lichess():
         return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
     @backoff.on_exception(backoff.constant,
-        (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
-        max_time=60,
-        interval=0.1,
-        giveup=is_final)
+                          (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
+                          max_time=60,
+                          interval=0.1,
+                          giveup=is_final)
     def api_get(self, path):
         url = urljoin(self.baseUrl, path)
         response = self.session.get(url, timeout=2)
@@ -54,10 +55,10 @@ class Lichess():
         return response.json()
 
     @backoff.on_exception(backoff.constant,
-        (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
-        max_time=60,
-	interval=0.1,
-        giveup=is_final)
+                          (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
+                          max_time=60,
+                          interval=0.1,
+                          giveup=is_final)
     def api_post(self, path, data=None):
         url = urljoin(self.baseUrl, path)
         response = self.session.post(url, data=data, timeout=2)

--- a/lichess.py
+++ b/lichess.py
@@ -28,7 +28,7 @@ ENDPOINTS = {
 
 
 # docs: https://lichess.org/api
-class Lichess():
+class Lichess:
 
     def __init__(self, token, url, version):
         self.version = version

--- a/logging_pool.py
+++ b/logging_pool.py
@@ -2,6 +2,7 @@ import traceback
 from multiprocessing.pool import Pool
 import multiprocessing
 
+
 # Shortcut to multiprocessing's logger
 def error(msg, *args):
     return multiprocessing.get_logger().error(msg, *args)

--- a/logging_pool.py
+++ b/logging_pool.py
@@ -16,7 +16,7 @@ class LogExceptions(object):
         try:
             result = self.__callable(*args, **kwargs)
 
-        except Exception as e:
+        except Exception:
             # Here we add some debugging help. If multiprocessing's
             # debugging is on, it will arrange to log the traceback
             error(traceback.format_exc())

--- a/logging_pool.py
+++ b/logging_pool.py
@@ -8,7 +8,7 @@ def error(msg, *args):
     return multiprocessing.get_logger().error(msg, *args)
 
 
-class LogExceptions(object):
+class LogExceptions:
     def __init__(self, callable):
         self.__callable = callable
 

--- a/model.py
+++ b/model.py
@@ -2,6 +2,7 @@ import sys
 import time
 from urllib.parse import urljoin
 
+
 class Challenge():
     def __init__(self, c_info):
         self.id = c_info["id"]
@@ -56,13 +57,14 @@ class Challenge():
     def __repr__(self):
         return self.__str__()
 
+
 class Game():
     def __init__(self, json, username, base_url, abort_time):
         self.username = username
         self.id = json.get("id")
         self.speed = json.get("speed")
         clock = json.get("clock", {}) or {}
-        self.clock_initial = clock.get("initial", 1000 * 3600 * 24 * 365 * 10) # unlimited = 10 years
+        self.clock_initial = clock.get("initial", 1000 * 3600 * 24 * 365 * 10)  # unlimited = 10 years
         self.clock_increment = clock.get("increment", 0)
         self.perf_name = json.get("perf").get("name") if json.get("perf") else "{perf?}"
         self.variant_name = json.get("variant")["name"]

--- a/model.py
+++ b/model.py
@@ -2,7 +2,7 @@ import time
 from urllib.parse import urljoin
 
 
-class Challenge():
+class Challenge:
     def __init__(self, c_info):
         self.id = c_info["id"]
         self.rated = c_info["rated"]
@@ -57,7 +57,7 @@ class Challenge():
         return self.__str__()
 
 
-class Game():
+class Game:
     def __init__(self, json, username, base_url, abort_time):
         self.username = username
         self.id = json.get("id")
@@ -108,7 +108,7 @@ class Game():
         return self.__str__()
 
 
-class Player():
+class Player:
     def __init__(self, json):
         self.id = json.get("id")
         self.name = json.get("name")

--- a/model.py
+++ b/model.py
@@ -88,7 +88,7 @@ class Game:
         return len(self.state["moves"]) < 6
 
     def ping(self, abort_in, terminate_in):
-        if (self.is_abortable()):
+        if self.is_abortable():
             self.abort_at = time.time() + abort_in
         self.terminate_at = time.time() + terminate_in
 

--- a/model.py
+++ b/model.py
@@ -1,4 +1,3 @@
-import sys
 import time
 from urllib.parse import urljoin
 

--- a/test_nothing.py
+++ b/test_nothing.py
@@ -1,4 +1,5 @@
 import pytest
 
+
 def test_nothing():
     assert True


### PR DESCRIPTION
Since the GitHub workflow now includes a check by flake8 for coding style, here are a collection of commits that fix the all warnings except `E501 line too long`. None of these changes should have any behavior changes.

The only changes that may require closer inspection are the following:

- The replacement of the loop with generator (commit 2412a7f) should be functionally equivalent.
- The replacement of bare `except:` with `except Exception:` (commit b8ff94a) should have no functional consequences.
- The conversion of EngineWrapper methods to functions (commit f957e80) should change nothing since those methods did not reference the `self` variable.