### PR TITLE
Submit challenge decline reason

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -49,6 +49,7 @@ challenge:                   # incoming challenges
   concurrency: 1             # number of games to play simultaneously
   sort_by: "best"            # possible values: "best", "first"
   accept_bot: false          # accepts challenges coming from other bots
+  only_bot: false            # accept challenges by bots only
   max_increment: 180         # maximum amount of increment to accaept a challenge. the max is 180. set to 0 for no increment
   min_increment: 0           # minimum amount of increment to accept a challenge
   variants:                  # chess variants to accept (http://lichess.org/variant)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -106,7 +106,11 @@ def start(li, user_profile, engine_factory, config):
                         if not chlng.is_supported_time_control(challenge["time_controls"], challenge.get("max_increment", 180), challenge.get("min_increment", 0)):
                             reason = "timeControl"
                         if not chlng.is_supported_mode(challenge["modes"]):
-                            reason = "casual" if chlng.rated else "rated"
+                            reason = "casual" if chlng.rated else "rated"                        
+                        if ( not challenge.get("accept_bot", False) ) and chlng.challenger_is_bot:
+                            reason = "noBot"
+                        if challenge.get("only_bot", False) and ( not chlng.challenger_is_bot ):
+                            reason = "onlyBot"
                         li.decline_challenge(chlng.id, reason=reason)
                         logger.info("    Decline {} for reason '{}'".format(chlng, reason))
                     except Exception:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -108,7 +108,7 @@ def start(li, user_profile, engine_factory, config):
                         if not chlng.is_supported_mode(challenge["modes"]):
                             reason = "casual" if chlng.rated else "rated"
                         li.decline_challenge(chlng.id, reason=reason)
-                        logger.info("    Decline {}".format(chlng))
+                        logger.info("    Decline {} for reason '{}'".format(chlng, reason))
                     except Exception:
                         pass
             elif event["type"] == "gameStart":

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -99,7 +99,15 @@ def start(li, user_profile, engine_factory, config):
                         challenge_queue = list_c
                 else:
                     try:
-                        li.decline_challenge(chlng.id)
+                        reason = "generic"
+                        challenge = config["challenge"]                         
+                        if not chlng.is_supported_variant(challenge["variants"]):
+                            reason = "variant"
+                        if not chlng.is_supported_time_control(challenge["time_controls"], challenge.get("max_increment", 180), challenge.get("min_increment", 0)):
+                            reason = "timeControl"
+                        if not chlng.is_supported_mode(challenge["modes"]):
+                            reason = "casual" if chlng.rated else "rated"
+                        li.decline_challenge(chlng.id, reason=reason)
                         logger.info("    Decline {}".format(chlng))
                     except Exception:
                         pass

--- a/lichess.py
+++ b/lichess.py
@@ -58,9 +58,10 @@ class Lichess:
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)
-    def api_post(self, path, data=None):
+    def api_post(self, path, data=None, headers=None):
+        print("post", path, data, headers)
         url = urljoin(self.baseUrl, path)
-        response = self.session.post(url, data=data, timeout=2)
+        response = self.session.post(url, data=data, headers=headers, timeout=2)
         response.raise_for_status()
         return response.json()
 
@@ -91,8 +92,8 @@ class Lichess:
     def accept_challenge(self, challenge_id):
         return self.api_post(ENDPOINTS["accept"].format(challenge_id))
 
-    def decline_challenge(self, challenge_id):
-        return self.api_post(ENDPOINTS["decline"].format(challenge_id))
+    def decline_challenge(self, challenge_id, reason = "generic"):
+        return self.api_post(ENDPOINTS["decline"].format(challenge_id), data=f"reason={reason}", headers={"Content-Type":"application/x-www-form-urlencoded"})
 
     def get_profile(self):
         profile = self.api_get(ENDPOINTS["profile"])

--- a/lichess.py
+++ b/lichess.py
@@ -58,8 +58,7 @@ class Lichess:
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)
-    def api_post(self, path, data=None, headers=None):
-        print("post", path, data, headers)
+    def api_post(self, path, data=None, headers=None):        
         url = urljoin(self.baseUrl, path)
         response = self.session.post(url, data=data, headers=headers, timeout=2)
         response.raise_for_status()

--- a/model.py
+++ b/model.py
@@ -30,7 +30,9 @@ class Challenge:
         return "rated" in supported if self.rated else "casual" in supported
 
     def is_supported(self, config):
-        if not config.get("accept_bot", False) and self.challenger_is_bot:
+        if ( not config.get("accept_bot", False) ) and self.challenger_is_bot:
+            return False
+        if config.get("only_bot", False) and ( not self.challenger_is_bot ):
             return False
         variants = config["variants"]
         tc = config["time_controls"]


### PR DESCRIPTION
`model.py` lists four reasons for declining a challenge, namely **bot**, **variant**, **time control** and **mode**. Added **only bot** to these. These are mapped to reasons **`variant`**, **`timeControl`**, **`casual`** / **`rated`** and **`noBot`** / **`onlyBot`** respectively in `lichess-bot.py` and are sent to `decline_challenge` in `lichess.py`. Also added **`only_bot`** option to `config.yml.default`.

In `lichess.py` added `reason` to `decline_challenge` with default `generic` and `headers` to `api_post` with default `None`, so that `application/x-www-form-urlencoded` header can be sent with declining challenge.