### PR TITLE
Call task_done() after processing an event on the control queue

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -136,6 +136,8 @@ def start(li, user_profile, engine_factory, config):
                         logger.info("    Skip missing {}".format(chlng))
                     queued_processes -= 1
 
+            control_queue.task_done()
+
     logger.info("Terminated")
     control_stream.terminate()
     control_stream.join()


### PR DESCRIPTION
This will indicate that all items in the queue have been processed, so
that queue.join() no longer blocks the main thread. This is described here
in the Python docs: https://docs.python.org/3/library/queue.html