### PR TITLE
Send go commands properly

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -27,10 +27,10 @@ engine:                      # engine settings
     Ponder: true
     Threads: 2               # max CPU threads the engine can use
     Hash: 256                # max memory (in megabytes) the engine can allocate
-#   go_commands:             # additional options to pass to the UCI go command
-#     nodes: 1               # Search so many nodes only.
-#     depth: 5               # Search depth ply only.
-#     movetime: 1000         # Integer. Search exactly movetime milliseconds.
+#  go_commands:             # additional options to pass to the UCI go command
+#    nodes: 1               # Search so many nodes only.
+#    depth: 5               # Search depth ply only.
+#    movetime: 1000         # Integer. Search exactly movetime milliseconds.
 # xboard_options:            # arbitrary xboard options passed to the engine
 #   cores: "4"
 #   memory: "4096"


### PR DESCRIPTION
There were several problems with sending custom go commands to the engine.

- Go commands config was not even sent to engine init ( only uci options ).

- An attempt was only made to read those setting in normal search, but this is never called ( only search with ponder option is ever called ).

- In config go command options were misaligned, making for invalid yml.

All those problems are fixed in this PR by sending the go command options to engine init, by adding an option to search with ponder, which ignores thinking times if any of the possible go command options is set, and sends the custom go command instead, and by aligning `config.yml.default` properly.