### PR TITLE
Upgrade python chess library to latest version (1.4.0)

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -24,7 +24,6 @@ engine:                      # engine settings
 #   cpuct: 3.1
   uci_options:               # arbitrary UCI options passed to the engine
     Move Overhead: 100       # increase if your bot flags games too often
-    Ponder: true
     Threads: 2               # max CPU threads the engine can use
     Hash: 256                # max memory (in megabytes) the engine can allocate
 #   go_commands:             # additional options to pass to the UCI go command

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -128,7 +128,14 @@ class UCIEngine(EngineWrapper):
 class XBoardEngine(EngineWrapper):
     def __init__(self, commands, options=None, silence_stderr=False):
         self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=subprocess.DEVNULL if silence_stderr else None)
+
+        egt_paths = options.pop("egtpath", {}) or {}
+        features = self.engine.protocol.features
+        egt_types_from_engine = features["egt"].split(",") if "egt" in features else []
+        for egt_type in egt_types_from_engine:
+            options[f"egtpath {egt_type}"] = egt_paths[egt_type]
         self.engine.configure(options)
+
         self.last_move_info = {}
         self.time_control_sent = False
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -29,21 +29,6 @@ def remove_managed_options(config):
     return {name: value for (name, value) in config.items() if not is_managed(name)}
 
 
-def print_handler_stats(info, stats):
-    for stat in stats:
-        if stat in info:
-            print("    {}: {}".format(stat, info[stat]))
-
-
-def get_handler_stats(info, stats):
-    stats_str = []
-    for stat in stats:
-        if stat in info:
-            stats_str.append("{}: {}".format(stat, info[stat]))
-
-    return stats_str
-
-
 class EngineWrapper:
     def __init__(self, commands, options=None, silence_stderr=False):
         pass
@@ -61,7 +46,13 @@ class EngineWrapper:
         pass
 
     def print_stats(self):
-        pass
+        for line in self.get_stats():
+            print(f"    {line}")
+
+    def get_stats(self):
+        info = self.last_move_info
+        stats = ["depth", "nps", "nodes", "score"]
+        return [f"{stat}: {info[stat]}" for stat in stats if stat in info]
 
     def get_opponent_info(self, game):
         pass
@@ -106,12 +97,6 @@ class UCIEngine(EngineWrapper):
 
     def stop(self):
         self.engine.protocol.send_line("stop")
-
-    def print_stats(self):
-        print_handler_stats(self.last_move_info, ["string", "depth", "nps", "nodes", "score"])
-
-    def get_stats(self):
-        return get_handler_stats(self.last_move_info, ["depth", "nps", "nodes", "score"])
 
     def get_opponent_info(self, game):
         name = game.opponent.name
@@ -170,12 +155,6 @@ class XBoardEngine(EngineWrapper):
 
     def stop(self):
         self.engine.protocol.send_line("?")
-
-    def print_stats(self):
-        print_handler_stats(self.last_move_info, ["depth", "nodes", "score"])
-
-    def get_stats(self):
-        return get_handler_stats(self.last_move_info, ["depth", "nodes", "score"])
 
     def get_opponent_info(self, game):
         if game.opponent.name and self.engine.protocol.features.get("name", True):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -17,12 +17,9 @@ def create_engine(config):
 
     silence_stderr = cfg.get("silence_stderr", False)
 
-    if engine_type == "xboard":
-        options = remove_managed_options(cfg.get("xboard_options", {}) or {})
-        return XBoardEngine(commands, options, silence_stderr)
-
-    options = remove_managed_options(cfg.get("uci_options", {}) or {})
-    return UCIEngine(commands, options, silence_stderr)
+    Engine = XBoardEngine if engine_type == "xboard" else UCIEngine
+    options = remove_managed_options(cfg.get(engine_type + "_options", {}) or {})
+    return Engine(commands, options, silence_stderr)
 
 
 def remove_managed_options(config):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1,13 +1,11 @@
 import os
-import chess
-import chess.xboard
-import chess.uci
+import chess.engine
 import backoff
 import subprocess
 
 
 @backoff.on_exception(backoff.expo, BaseException, max_time=120)
-def create_engine(config, board):
+def create_engine(config):
     cfg = config["engine"]
     engine_path = os.path.join(cfg["dir"], cfg["name"])
     engine_type = cfg.get("protocol")
@@ -20,9 +18,9 @@ def create_engine(config, board):
     silence_stderr = cfg.get("silence_stderr", False)
 
     if engine_type == "xboard":
-        return XBoardEngine(board, commands, cfg.get("xboard_options", {}) or {}, silence_stderr)
+        return XBoardEngine(commands, cfg.get("xboard_options", {}) or {}, silence_stderr)
 
-    return UCIEngine(board, commands, cfg.get("uci_options", {}) or {}, silence_stderr)
+    return UCIEngine(commands, cfg.get("uci_options", {}) or {}, silence_stderr)
 
 
 def print_handler_stats(info, stats):
@@ -41,7 +39,7 @@ def get_handler_stats(info, stats):
 
 
 class EngineWrapper:
-    def __init__(self, board, commands, options=None, silence_stderr=False):
+    def __init__(self, commands, options=None, silence_stderr=False):
         pass
 
     def set_time_control(self, game):
@@ -50,7 +48,10 @@ class EngineWrapper:
     def first_search(self, board, movetime):
         pass
 
-    def search(self, board, wtime, btime, winc, binc):
+    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):
+        pass
+
+    def ponderhit(self):
         pass
 
     def print_stats(self):
@@ -60,184 +61,111 @@ class EngineWrapper:
         pass
 
     def name(self):
-        return self.engine.name
+        return self.engine.id["name"]
+
+    def stop(self):
+        pass
 
     def quit(self):
         self.engine.quit()
 
 
 class UCIEngine(EngineWrapper):
-    def __init__(self, board, commands, options, silence_stderr=False):
-        commands = commands[0] if len(commands) == 1 else commands
-        self.go_commands = options.get("go_commands", {})
-
-        self.engine = chess.uci.popen_engine(commands, stderr=subprocess.DEVNULL if silence_stderr else None)
-        self.engine.uci()
-
-        if options:
-            self.engine.setoption(options)
-
-        self.engine.setoption({
-            "UCI_Variant": type(board).uci_variant,
-            "UCI_Chess960": board.chess960
-        })
-        self.engine.position(board)
-
-        info_handler = chess.uci.InfoHandler()
-        self.engine.info_handlers.append(info_handler)
+    def __init__(self, commands, options, silence_stderr=False):
+        self.go_commands = options.pop("go_commands", {})
+        self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=subprocess.DEVNULL if silence_stderr else None)
+        self.engine.configure(options)
+        self.last_move_info = {}
 
     def first_search(self, board, movetime):
-        self.engine.position(board)
-        best_move, _ = self.engine.go(movetime=movetime)
-        return best_move
+        result = self.engine.play(board, chess.engine.Limit(time=movetime / 1000), info=chess.engine.INFO_ALL)
+        self.last_move_info = result.info
+        return result.move
 
     def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):
-        self.engine.position(board)
-        best_move, ponder_move = self.engine.go(
-            wtime=wtime,
-            btime=btime,
-            winc=winc,
-            binc=binc,
-            ponder=ponder
-        )
-        return (best_move, ponder_move)
-
-    def search(self, board, wtime, btime, winc, binc):
-        self.engine.position(board)
         cmds = self.go_commands
-        best_move, _ = self.engine.go(
-            wtime=wtime,
-            btime=btime,
-            winc=winc,
-            binc=binc,
-            depth=cmds.get("depth"),
-            nodes=cmds.get("nodes"),
-            movetime=cmds.get("movetime")
-        )
-        return best_move
+        time_limit = chess.engine.Limit(white_clock=wtime / 1000,
+                                        black_clock=btime / 1000,
+                                        white_inc=winc / 1000,
+                                        black_inc=binc / 1000,
+                                        depth=cmds.get("depth"),
+                                        nodes=cmds.get("nodes"),
+                                        time=cmds.get("movetime"))
+        result = self.engine.play(board, time_limit, ponder=ponder, info=chess.engine.INFO_ALL)
+        self.last_move_info = result.info
+        return (result.move, result.ponder)
 
     def stop(self):
-        self.engine.stop()
+        self.engine.protocol.send_line("stop")
 
     def print_stats(self):
-        print_handler_stats(self.engine.info_handlers[0].info, ["string", "depth", "nps", "nodes", "score"])
+        print_handler_stats(self.last_move_info, ["string", "depth", "nps", "nodes", "score"])
 
     def get_stats(self):
-        return get_handler_stats(self.engine.info_handlers[0].info, ["depth", "nps", "nodes", "score"])
+        return get_handler_stats(self.last_move_info, ["depth", "nps", "nodes", "score"])
 
     def get_opponent_info(self, game):
         name = game.opponent.name
-        if name:
+        if name and "UCI_Opponent" in self.engine.protocol.config:
             rating = game.opponent.rating if game.opponent.rating is not None else "none"
             title = game.opponent.title if game.opponent.title else "none"
             player_type = "computer" if title == "BOT" else "human"
-            self.engine.setoption({"UCI_Opponent": "{} {} {} {}".format(title, rating, player_type, name)})
+            self.engine.configure({"UCI_Opponent": f"{title} {rating} {player_type} {name}"})
+
+    def ponderhit(self):
+        self.engine.protocol.send_line("ponderhit")
 
 
 class XBoardEngine(EngineWrapper):
-    def __init__(self, board, commands, options=None, silence_stderr=False):
-        commands = commands[0] if len(commands) == 1 else commands
-        self.engine = chess.xboard.popen_engine(commands, stderr=subprocess.DEVNULL if silence_stderr else None)
-
-        self.engine.xboard()
-
-        if board.chess960:
-            self.engine.send_variant("fischerandom")
-        elif type(board).uci_variant != "chess":
-            self.engine.send_variant(type(board).uci_variant)
-
-        if options:
-            self._handle_options(options)
-
-        if board.fen() != chess.STARTING_FEN:
-            self.engine.force()
-            if board.root().fen() != chess.STARTING_FEN:
-                self.engine.setboard(board.root())
-            for move in board.move_stack:
-                self.engine.usermove(move)
-        self.last_fen_seen = board.fen()
-
-        post_handler = chess.xboard.PostHandler()
-        self.engine.post_handlers.append(post_handler)
-
-    def _handle_options(self, options):
-        for option, value in options.items():
-            if option == "memory":
-                self.engine.memory(value)
-            elif option == "cores":
-                self.engine.cores(value)
-            elif option == "egtpath":
-                for egttype, egtpath in value.items():
-                    try:
-                        self.engine.egtpath(egttype, egtpath)
-                    except chess.EngineStateException:
-                        # If the user specifies more TBs than the engine supports, ignore the error.
-                        pass
-            else:
-                try:
-                    self.engine.features.set_option(option, value)
-                except chess.EngineStateException:
-                    pass
+    def __init__(self, commands, options=None, silence_stderr=False):
+        self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=subprocess.DEVNULL if silence_stderr else None)
+        self.engine.configure(options)
+        self.last_move_info = {}
+        self.time_control_sent = False
 
     def set_time_control(self, game):
-        self.minutes = game.clock_initial / 1000 // 60
+        self.minutes = game.clock_initial // 1000 // 60
         self.seconds = game.clock_initial // 1000 % 60
         self.inc = game.clock_increment // 1000
-        self.send_time()
 
     def send_time(self):
-        self.engine.level(0, self.minutes, self.seconds, self.inc)
-
-    def send_last_move(self, board):
-        if board.fen() == self.last_fen_seen:
-            return
-        self.engine.force()
-        try:
-            self.engine.usermove(board.peek())
-        except IndexError:
-            self.engine.setboard(board)
-        self.last_fen_seen = board.fen()
+        self.engine.protocol.send_line(f"level 0 {self.minutes}:{self.seconds} {self.inc}")
+        self.time_control_sent = True
 
     def first_search(self, board, movetime):
-        self.send_last_move(board)
-        self.engine.st(movetime // 1000)
-        bestmove = self.engine.go()
-        self.send_time()
-
-        return bestmove
-
-    def search(self, board, wtime, btime, winc, binc):
-        self.send_last_move(board)
-
-        # XBoard engines expect time in units of 1/100 seconds.
-        if board.turn == chess.WHITE:
-            self.engine.time(wtime // 10)
-            self.engine.otim(btime // 10)
-        else:
-            self.engine.time(btime // 10)
-            self.engine.otim(wtime // 10)
-        return self.engine.go()
+        result = self.engine.play(board,
+                                  chess.engine.Limit(time=movetime // 1000),
+                                  info=chess.engine.INFO_ALL)
+        self.last_move_info = result.info
+        return result.move
 
     def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):
-        return self.search(board, wtime, btime, winc, binc), None
+        if not self.time_control_sent:
+            self.send_time()
+
+        time_limit = chess.engine.Limit(white_clock=wtime / 1000,
+                                        black_clock=btime / 1000)
+        result = self.engine.play(board,
+                                  time_limit,
+                                  info=chess.engine.INFO_ALL,
+                                  ponder=ponder)
+        self.last_move_info = result.info
+        return result.move, None
+
+    def stop(self):
+        self.engine.protocol.send_line("?")
 
     def print_stats(self):
-        print_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
+        print_handler_stats(self.last_move_info, ["depth", "nodes", "score"])
 
     def get_stats(self):
-        return get_handler_stats(self.engine.post_handlers[0].post, ["depth", "nodes", "score"])
-
-    def name(self):
-        try:
-            return self.engine.features.get("myname")
-        except Exception:
-            return None
+        return get_handler_stats(self.last_move_info, ["depth", "nodes", "score"])
 
     def get_opponent_info(self, game):
-        title = game.opponent.title + " " if game.opponent.title else ""
-        if game.opponent.name:
-            self.engine.opponent_name(title + game.opponent.name)
+        if game.opponent.name and self.engine.protocol.features.get("name", True):
+            title = game.opponent.title + " " if game.opponent.title else ""
+            self.engine.protocol.send_line(f"name {title}{game.opponent.name}")
         if game.me.rating is not None and game.opponent.rating is not None:
-            self.engine.rating(game.me.rating, game.opponent.rating)
+            self.engine.protocol.send_line(f"rating {game.me.rating} {game.opponent.rating}")
         if game.opponent.title == "BOT":
-            self.engine.computer()
+            self.engine.protocol.send_line("computer")

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -18,9 +18,18 @@ def create_engine(config):
     silence_stderr = cfg.get("silence_stderr", False)
 
     if engine_type == "xboard":
-        return XBoardEngine(commands, cfg.get("xboard_options", {}) or {}, silence_stderr)
+        options = remove_managed_options(cfg.get("xboard_options", {}) or {})
+        return XBoardEngine(commands, options, silence_stderr)
 
-    return UCIEngine(commands, cfg.get("uci_options", {}) or {}, silence_stderr)
+    options = remove_managed_options(cfg.get("uci_options", {}) or {})
+    return UCIEngine(commands, options, silence_stderr)
+
+
+def remove_managed_options(config):
+    def is_managed(key):
+        return chess.engine.Option(key, None, None, None, None, None).is_managed()
+
+    return {name: value for (name, value) in config.items() if not is_managed(name)}
 
 
 def print_handler_stats(info, stats):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -99,7 +99,7 @@ class UCIEngine(EngineWrapper):
                                         black_inc=binc / 1000,
                                         depth=cmds.get("depth"),
                                         nodes=cmds.get("nodes"),
-                                        time=cmds.get("movetime"))
+                                        time=float(cmds.get("movetime")) / 1000)
         result = self.engine.play(board, time_limit, ponder=ponder, info=chess.engine.INFO_ALL)
         self.last_move_info = result.info
         return (result.move, result.ponder)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -374,11 +374,11 @@ def get_book_move(board, config):
             try:
                 selection = config.get("selection", "weighted_random")
                 if selection == "weighted_random":
-                    move = reader.weighted_choice(board).move()
+                    move = reader.weighted_choice(board).move
                 elif selection == "uniform_random":
-                    move = reader.choice(board, minimum_weight=config.get("min_weight", 1)).move()
+                    move = reader.choice(board, minimum_weight=config.get("min_weight", 1)).move
                 elif selection == "best_move":
-                    move = reader.find(board, minimum_weight=config.get("min_weight", 1)).move()
+                    move = reader.find(board, minimum_weight=config.get("min_weight", 1)).move
             except IndexError:
                 # python-chess raises "IndexError" if no entries found
                 move = None

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -100,16 +100,16 @@ def start(li, user_profile, engine_factory, config):
                 else:
                     try:
                         reason = "generic"
-                        challenge = config["challenge"]                         
+                        challenge = config["challenge"]
                         if not chlng.is_supported_variant(challenge["variants"]):
                             reason = "variant"
                         if not chlng.is_supported_time_control(challenge["time_controls"], challenge.get("max_increment", 180), challenge.get("min_increment", 0)):
                             reason = "timeControl"
                         if not chlng.is_supported_mode(challenge["modes"]):
-                            reason = "casual" if chlng.rated else "rated"                        
-                        if ( not challenge.get("accept_bot", False) ) and chlng.challenger_is_bot:
+                            reason = "casual" if chlng.rated else "rated"
+                        if not challenge.get("accept_bot", False) and chlng.challenger_is_bot:
                             reason = "noBot"
-                        if challenge.get("only_bot", False) and ( not chlng.challenger_is_bot ):
+                        if challenge.get("only_bot", False) and not chlng.challenger_is_bot:
                             reason = "onlyBot"
                         li.decline_challenge(chlng.id, reason=reason)
                         logger.info("    Decline {} for reason '{}'".format(chlng, reason))
@@ -383,7 +383,7 @@ def get_book_move(board, config):
         if move is not None:
             logger.info("Got move {} from book {}".format(move, book))
             return move
-        
+
     return None
 
 

--- a/lichess.py
+++ b/lichess.py
@@ -58,7 +58,7 @@ class Lichess:
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)
-    def api_post(self, path, data=None, headers=None):        
+    def api_post(self, path, data=None, headers=None):
         url = urljoin(self.baseUrl, path)
         response = self.session.post(url, data=data, headers=headers, timeout=2)
         response.raise_for_status()
@@ -91,8 +91,8 @@ class Lichess:
     def accept_challenge(self, challenge_id):
         return self.api_post(ENDPOINTS["accept"].format(challenge_id))
 
-    def decline_challenge(self, challenge_id, reason = "generic"):
-        return self.api_post(ENDPOINTS["decline"].format(challenge_id), data=f"reason={reason}", headers={"Content-Type":"application/x-www-form-urlencoded"})
+    def decline_challenge(self, challenge_id, reason="generic"):
+        return self.api_post(ENDPOINTS["decline"].format(challenge_id), data=f"reason={reason}", headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     def get_profile(self):
         profile = self.api_get(ENDPOINTS["profile"])

--- a/model.py
+++ b/model.py
@@ -31,9 +31,9 @@ class Challenge:
         return "rated" in supported if self.rated else "casual" in supported
 
     def is_supported(self, config):
-        if ( not config.get("accept_bot", False) ) and self.challenger_is_bot:
+        if not config.get("accept_bot", False) and self.challenger_is_bot:
             return False
-        if config.get("only_bot", False) and ( not self.challenger_is_bot ):
+        if config.get("only_bot", False) and not self.challenger_is_bot:
             return False
         variants = config["variants"]
         tc = config["time_controls"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2018.11.29
 chardet==3.0.4
 idna==2.8
-chess==1.3.3
+chess==1.4.0
 PyYAML>=4.2b1
 requests>=2.21.0
 urllib3==1.24.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2018.11.29
 chardet==3.0.4
 idna==2.8
-python-chess==0.24.1
+chess==1.3.3
 PyYAML>=4.2b1
 requests>=2.21.0
 urllib3==1.24.2


### PR DESCRIPTION
This commit updates lichess-bot to use the latest version of the python
chess library. The main result is a large decrease in the amount of code
in engine_wrapper.py due to so many functions being incorporated into
the chess library.

One annoying difference is that the new library rejects the 'usermove'
feature from Xboard engines, which is rare among chess engine
interfaces.

I hope this can be tested by a variety of engines to make sure it is on
par with the current lichess-bot. This would close #240.