### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lichess-bot
-A bridge between [Lichess API](https://lichess.org/api#tag/Chess-Bot) and bots.
+A bridge between [Lichess API](https://lichess.org/api#tag/Bot) and bots.
 
 
 ## How to Install

--- a/conversation.py
+++ b/conversation.py
@@ -22,7 +22,7 @@ class Conversation:
         elif cmd == "name":
             self.send_reply(line, "{} (lichess-bot v{})".format(self.engine.name(), self.version))
         elif cmd == "howto":
-            self.send_reply(line, "How to run your own bot: lichess.org/api#tag/Chess-Bot")
+            self.send_reply(line, "How to run your own bot: lichess.org/api#tag/Bot")
         elif cmd == "eval" and line.room == "spectator":
             stats = self.engine.get_stats()
             self.send_reply(line, ", ".join(stats))

--- a/conversation.py
+++ b/conversation.py
@@ -22,7 +22,7 @@ class Conversation:
         elif cmd == "name":
             self.send_reply(line, "{} (lichess-bot v{})".format(self.engine.name(), self.version))
         elif cmd == "howto":
-            self.send_reply(line, "How to run your own bot: lichess.org/api#tag/Bot")
+            self.send_reply(line, "How to run your own bot: Check out 'Lichess Bot API'")
         elif cmd == "eval" and line.room == "spectator":
             stats = self.engine.get_stats()
             self.send_reply(line, ", ".join(stats))


### PR DESCRIPTION
The link under lichess api was directed to the old bot api url. I’ve changed it to use https://lichess.org/api#tag/Bot instead of https://lichess.org/api#tag/Chess-Bot as the latter redirects to https://lichess.org/api

Sorry I have made 3 different PR’s at the same time, but I have done so because I feel that all 3 are totally different and unrelated to each other.