### PR TITLE
Delete code for old python versions and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A bridge between [Lichess API](https://lichess.org/api#tag/Bot) and bots.
 ## How to Install
 
 ### Mac/Linux:
-- NOTE: Only Python 3 is supported!
+- NOTE: Only Python 3.7 or later is supported!
 - Download the repo into lichess-bot directory
 - Navigate to the directory in cmd/Terminal: `cd lichess-bot`
 - Install pip: `apt install python3-pip`
@@ -22,7 +22,7 @@ python3 -m pip install -r requirements.txt
 
 ### Windows:
 - Here is a video on how to install the bot: (https://youtu.be/w-aJFk00POQ). Or you may proceed to the next steps.
-- NOTE: Only Python 3 is supported!
+- NOTE: Only Python 3.7 or later is supported!
 - If you don't have Python, you may download it here: (https://www.python.org/downloads/). When installing it, enable "add Python to PATH", then go to custom installation (this may be not necessary, but on some computers it won't work otherwise) and enable all options (especially "install for all users"), except the last . It's better to install Python in a path without spaces, like "C:\Python\".
 - To type commands it's better to use PowerShell. Go to Start menu and type "PowerShell" (you may use cmd too, but sometimes it may not work).
 - Then you may need to upgrade pip. Execute "python -m pip install --upgrade pip" in PowerShell.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -22,11 +22,7 @@ from ColorLogger import enable_color_logging
 
 logger = logging.getLogger(__name__)
 
-try:
-    from http.client import RemoteDisconnected
-    # New in version 3.5: Previously, BadStatusLine('') was raised.
-except ImportError:
-    from http.client import BadStatusLine as RemoteDisconnected
+from http.client import RemoteDisconnected
 
 __version__ = "1.2.0"
 

--- a/lichess.py
+++ b/lichess.py
@@ -2,13 +2,7 @@ import requests
 from urllib.parse import urljoin
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 from urllib3.exceptions import ProtocolError
-
-try:
-    from http.client import RemoteDisconnected
-    # New in version 3.5: Previously, BadStatusLine('') was raised.
-except ImportError:
-    from http.client import BadStatusLine as RemoteDisconnected
-
+from http.client import RemoteDisconnected
 import backoff
 
 ENDPOINTS = {


### PR DESCRIPTION
Lichess bot does not support python 3.6 or earlier, so I deleted the code that was for python 3.4 or earlier and changed the README to show that it only supports python 3.7 or later.