### PR TITLE
Replace print() with logging

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,9 @@
 import yaml
 import os
 import os.path
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def load_config(config_file):
@@ -8,7 +11,7 @@ def load_config(config_file):
         try:
             CONFIG = yaml.safe_load(stream)
         except Exception as e:
-            print("There appears to be a syntax problem with your config.yml")
+            logger.error("There appears to be a syntax problem with your config.yml")
             raise e
 
         # [section, type, error message]

--- a/conversation.py
+++ b/conversation.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 class Conversation:
     def __init__(self, game, engine, xhr, version, challenge_queue):
         self.game = game
@@ -9,7 +14,7 @@ class Conversation:
     command_prefix = "!"
 
     def react(self, line, game):
-        print("*** {} [{}] {}: {}".format(self.game.url(), line.room, line.username, line.text.encode("utf-8")))
+        logger.info("*** {} [{}] {}: {}".format(self.game.url(), line.room, line.username, line.text.encode("utf-8")))
         if (line.text[0] == self.command_prefix):
             self.command(line, game, line.text[1:].lower())
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -2,6 +2,9 @@ import os
 import chess.engine
 import backoff
 import subprocess
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @backoff.on_exception(backoff.expo, BaseException, max_time=120)
@@ -53,7 +56,7 @@ class EngineWrapper:
 
     def print_stats(self):
         for line in self.get_stats():
-            print(f"    {line}")
+            logger.info(f"    {line}")
 
     def get_stats(self):
         info = self.last_move_info

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -232,7 +232,9 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
 def choose_first_move(engine, board):
     # need to hardcode first movetime (10000 ms) since Lichess has 30 sec limit.
-    return engine.first_search(board, 10000)
+    search_time = 10000
+    logger.info("Searching for time {}".format(search_time))
+    return engine.first_search(board, search_time)
 
 
 def get_book_move(board, polyglot_cfg):


### PR DESCRIPTION
Log all messages to the user with the logging module. Before, if the
user specifies a logfile via -l, the print() statements would be missed.

Also, log the usage of the choose_first_move() function similarly
to the choose_move() function.