### PR TITLE
Notify engines of the final endgame state

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -32,6 +32,21 @@ def remove_managed_options(config):
     return {name: value for (name, value) in config.items() if not is_managed(name)}
 
 
+class Termination:
+    MATE = 'mate'
+    TIMEOUT = 'outoftime'
+    RESIGN = 'resign'
+    ABORT = 'aborted'
+    DRAW = 'draw'
+
+
+class Game_Ending:
+    WHITE_WINS = '1-0'
+    BLACK_WINS = '0-1'
+    DRAW = '1/2-1/2'
+    INCOMPLETE = '*'
+
+
 class EngineWrapper:
     def __init__(self, commands, options, stderr):
         pass
@@ -151,25 +166,24 @@ class XBoardEngine(EngineWrapper):
         termination = game.state.get('status')
 
         if winner == 'white':
-            game_result = '1-0'
+            game_result = Game_Ending.WHITE_WINS
         elif winner == 'black':
-            game_result = '0-1'
-        elif termination == 'draw':
-            game_result = '1/2-1/2'
+            game_result = Game_Ending.BLACK_WINS
+        elif termination == Termination.DRAW:
+            game_result = Game_Ending.DRAW
         else:
-            game_result = '*'
+            game_result = Game_Ending.INCOMPLETE
 
-
-        if termination == 'mate':
+        if termination == Termination.MATE:
             endgame_message = winner.title() + ' mates'
-        elif termination == 'outoftime':
+        elif termination == Termination.TIMEOUT:
             endgame_message = 'Time forfeiture'
-        elif termination == 'resign':
+        elif termination == Termination.RESIGN:
             resigner = 'black' if winner == 'white' else 'white'
             endgame_message = resigner.title() + ' resigns'
-        elif termination == 'aborted':
+        elif termination == Termination.ABORT:
             endgame_message = 'Game aborted'
-        elif termination == 'draw':
+        elif termination == Termination.DRAW:
             if board.is_fifty_moves():
                 endgame_message = '50-move rule'
             elif board.is_repetition():

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -147,6 +147,7 @@ class XBoardEngine(EngineWrapper):
         return self.search(board, time_limit, ponder)
 
     def report_game_result(self, game, board):
+        # Send final moves, if any, to engine
         self.engine.protocol._new(board, None, {})
 
         winner = game.state.get('winner')

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -156,10 +156,11 @@ class XBoardEngine(EngineWrapper):
             game_result = '1-0'
         elif winner == 'black':
             game_result = '0-1'
-        elif termination == 'aborted':
-            game_result = '*'
-        else:
+        elif termination == 'draw':
             game_result = '1/2-1/2'
+        else:
+            game_result = '*'
+
 
         if termination == 'mate':
             endgame_message = winner.title() + ' mates'

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -200,6 +200,8 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                                 best_move, ponder_move = choose_move(engine, board, game, start_time, move_overhead)
                     li.make_move(game.id, best_move)
                     ponder_thread, ponder_uci = start_pondering(engine, board, game, is_uci_ponder, best_move, ponder_move, start_time, move_overhead)
+                elif is_game_over(game):
+                    engine.report_game_result(game, board)
 
                 wb = 'w' if board.turn == chess.WHITE else 'b'
                 game.ping(config.get("abort_time", 20), (upd[f"{wb}time"] + upd[f"{wb}inc"]) / 1000 + 60)


### PR DESCRIPTION
To Xboard engines: Send the final move (if any) and the result of the game.

To UCI engines: Send the final state of the board.