### PR TITLE
some problems in config.yml.default

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -33,11 +33,7 @@ engine:                      # engine settings
 # xboard_options:            # arbitrary xboard options passed to the engine
 #   cores: "4"
 #   memory: "4096"
-#   egtpath:                 # dir containing egtb, relative to this project
-#     gaviota: "Gaviota path"
-#     nalimov: "Nalimov Path"
-#     scorpio: "Scorpio Path"
-#     syzygy: "Syzygy Path"
+#   SyzygyPath: "Syzygy Path"         # dir containing Syzygytb, relative to this project
   silence_stderr: false      # some engines (yes you, leela) are very noisy
 
 abort_time: 20               # time to abort a game in seconds when there is no activity


### PR DESCRIPTION
i got this error :
"chess.engine.EngineError: engine does not support option egtpath (available options: Debug Log File, Contempt, Analysis Contempt, Threads, Hash, Clear Hash, Ponder, MultiPV, Skill Level, Move Overhead, Slow Mover, nodestime, UCI_Chess960, UCI_AnalyseMode, UCI_LimitStrength, UCI_Elo, UCI_ShowWDL, SyzygyPath, SyzygyProbeDepth, Syzygy50MoveRule, SyzygyProbeLimit, Use NNUE, EvalFile
"
Check my request
If there is no problem add this