### PR TITLE
Syzygy tablebases

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -31,10 +31,15 @@ engine:                      # engine settings
 #     nodes: 1               # Search so many nodes only.
 #     depth: 5               # Search depth ply only.
 #     movetime: 1000         # Integer. Search exactly movetime milliseconds.
-
 # xboard_options:            # arbitrary xboard options passed to the engine
 #   cores: "4"
 #   memory: "4096"
+
+#   egtpath:                 # dir containing egtb, relative to this project
+#     gaviota: "Gaviota path"
+#     nalimov: "Nalimov Path"
+#     scorpio: "Scorpio Path"
+#     syzygy: "Syzygy Path"
 
   silence_stderr: false      # some engines (yes you, leela) are very noisy
 

--- a/config.yml.default
+++ b/config.yml.default
@@ -30,14 +30,11 @@ engine:                      # engine settings
 #     nodes: 1               # Search so many nodes only.
 #     depth: 5               # Search depth ply only.
 #     movetime: 1000         # Integer. Search exactly movetime milliseconds.
+#   SyzygyPath: "Syzygy Path"         # dir containing Syzygytb, relative to this project
 # xboard_options:            # arbitrary xboard options passed to the engine
 #   cores: "4"
 #   memory: "4096"
-#   egtpath:                 # dir containing egtb, relative to this project
-#     gaviota: "Gaviota path"
-#     nalimov: "Nalimov Path"
-#     scorpio: "Scorpio Path"
-#     syzygy: "Syzygy Path"
+
   silence_stderr: false      # some engines (yes you, leela) are very noisy
 
 abort_time: 20               # time to abort a game in seconds when there is no activity

--- a/config.yml.default
+++ b/config.yml.default
@@ -26,11 +26,12 @@ engine:                      # engine settings
     Move Overhead: 100       # increase if your bot flags games too often
     Threads: 2               # max CPU threads the engine can use
     Hash: 256                # max memory (in megabytes) the engine can allocate
+#   SyzygyPath: "Syzygy Path"# dir containing Syzygytb, relative to this project
 #   go_commands:             # additional options to pass to the UCI go command
 #     nodes: 1               # Search so many nodes only.
 #     depth: 5               # Search depth ply only.
 #     movetime: 1000         # Integer. Search exactly movetime milliseconds.
-#   SyzygyPath: "Syzygy Path"         # dir containing Syzygytb, relative to this project
+
 # xboard_options:            # arbitrary xboard options passed to the engine
 #   cores: "4"
 #   memory: "4096"


### PR DESCRIPTION
i got this error :
"chess.engine.EngineError: engine does not support option egtpath (available options: Debug Log File, Contempt, Analysis Contempt, Threads, Hash, Clear Hash, Ponder, MultiPV, Skill Level, Move Overhead, Slow Mover, nodestime, UCI_Chess960, UCI_AnalyseMode, UCI_LimitStrength, UCI_Elo, UCI_ShowWDL, SyzygyPath, SyzygyProbeDepth, Syzygy50MoveRule, SyzygyProbeLimit, Use NNUE, EvalFile
"
Check my request
If there is no problem add this