### PR TITLE
Fix UCI pondering issue

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -36,20 +36,17 @@ class EngineWrapper:
     def set_time_control(self, game):
         pass
 
-    def first_search(self, board, movetime):
-        return self.search(board, chess.engine.Limit(time=movetime // 1000), False)
+    def first_search(self, board, movetime, ponder):
+        return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder)
 
-    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):
+    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder):
         pass
 
     def search(self, board, time_limit, ponder):
         result = self.engine.play(board, time_limit, info=chess.engine.INFO_ALL, ponder=ponder)
         self.last_move_info = result.info
         self.print_stats()
-        return result.move, result.ponder
-
-    def ponderhit(self):
-        pass
+        return result.move
 
     def print_stats(self):
         for line in self.get_stats():
@@ -80,7 +77,7 @@ class UCIEngine(EngineWrapper):
         self.engine.configure(options)
         self.last_move_info = {}
 
-    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):
+    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder):
         cmds = self.go_commands
         movetime = cmds.get("movetime")
         if movetime is not None:
@@ -104,9 +101,6 @@ class UCIEngine(EngineWrapper):
             title = game.opponent.title if game.opponent.title else "none"
             player_type = "computer" if title == "BOT" else "human"
             self.engine.configure({"UCI_Opponent": f"{title} {rating} {player_type} {name}"})
-
-    def ponderhit(self):
-        self.engine.protocol.send_line("ponderhit")
 
 
 class XBoardEngine(EngineWrapper):
@@ -132,7 +126,7 @@ class XBoardEngine(EngineWrapper):
         self.engine.protocol.send_line(f"level 0 {self.minutes}:{self.seconds} {self.inc}")
         self.time_control_sent = True
 
-    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder=False):
+    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder):
         if not self.time_control_sent:
             self.send_time()
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -12,7 +12,6 @@ import logging_pool
 import signal
 import time
 import backoff
-import threading
 from config import load_config
 from conversation import Conversation, ChatLine
 from functools import partial
@@ -167,9 +166,6 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     move_overhead = config.get("move_overhead", 1000)
     polyglot_cfg = engine_cfg.get("polyglot", {})
 
-    ponder_thread = None
-    ponder_uci = None
-
     first_move = True
     while not terminated:
         try:
@@ -190,16 +186,13 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     start_time = time.perf_counter_ns()
                     fake_thinking(config, board, game)
 
-                    best_move, ponder_move = get_book_move(board, polyglot_cfg), None
+                    best_move = get_book_move(board, polyglot_cfg)
                     if best_move is None:
                         if len(board.move_stack) < 2:
-                            best_move, ponder_move = choose_first_move(engine, board)
+                            best_move = choose_first_move(engine, board, is_uci_ponder)
                         else:
-                            best_move, ponder_move = get_pondering_results(ponder_thread, ponder_uci, game, board, engine)
-                            if best_move is None:
-                                best_move, ponder_move = choose_move(engine, board, game, start_time, move_overhead)
+                            best_move = choose_move(engine, board, game, is_uci_ponder, start_time, move_overhead)
                     li.make_move(game.id, best_move)
-                    ponder_thread, ponder_uci = start_pondering(engine, board, game, is_uci_ponder, best_move, ponder_move, start_time, move_overhead)
 
                 wb = 'w' if board.turn == chess.WHITE else 'b'
                 game.ping(config.get("abort_time", 20), (upd[f"{wb}time"] + upd[f"{wb}inc"]) / 1000 + 60)
@@ -222,17 +215,15 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     logger.info("--- {} Game over".format(game.url()))
     engine.stop()
     engine.quit()
-    if ponder_thread is not None:
-        ponder_thread.join()
 
     # This can raise queue.NoFull, but that should only happen if we're not processing
     # events fast enough and in this case I believe the exception should be raised
     control_queue.put_nowait({"type": "local_game_done"})
 
 
-def choose_first_move(engine, board):
+def choose_first_move(engine, board, ponder):
     # need to hardcode first movetime (10000 ms) since Lichess has 30 sec limit.
-    return engine.first_search(board, 10000)
+    return engine.first_search(board, 10000, ponder)
 
 
 def get_book_move(board, polyglot_cfg):
@@ -273,7 +264,7 @@ def get_book_move(board, polyglot_cfg):
     return None
 
 
-def choose_move(engine, board, game, start_time, move_overhead):
+def choose_move(engine, board, game, ponder, start_time, move_overhead):
     wtime = game.state["wtime"]
     btime = game.state["btime"]
     pre_move_time = int((time.perf_counter_ns() - start_time) / 1000000)
@@ -283,49 +274,7 @@ def choose_move(engine, board, game, start_time, move_overhead):
         btime = max(0, btime - move_overhead - pre_move_time)
 
     logger.info("Searching for wtime {} btime {}".format(wtime, btime))
-    return engine.search_with_ponder(board, wtime, btime, game.state["winc"], game.state["binc"])
-
-
-def start_pondering(engine, board, game, is_uci_ponder, best_move, ponder_move, start_time, move_overhead):
-    if not is_uci_ponder or ponder_move is None:
-        return None, None
-
-    ponder_board = board.copy()
-    ponder_board.push(best_move)
-    ponder_board.push(ponder_move)
-
-    wtime = game.state["wtime"]
-    btime = game.state["btime"]
-    setup_time = int((time.perf_counter_ns() - start_time) / 1000000)
-    if board.turn == chess.WHITE:
-        wtime = max(0, wtime - move_overhead - setup_time + game.state["winc"])
-    else:
-        btime = max(0, btime - move_overhead - setup_time + game.state["binc"])
-
-    def ponder_thread_func(game, engine, board, wtime, btime, winc, binc):
-        global ponder_results
-        best_move, ponder_move = engine.search_with_ponder(board, wtime, btime, winc, binc, True)
-        ponder_results[game.id] = (best_move, ponder_move)
-
-    logger.info("Pondering for wtime {} btime {}".format(wtime, btime))
-    ponder_thread = threading.Thread(target=ponder_thread_func, args=(game, engine, ponder_board, wtime, btime, game.state["winc"], game.state["binc"]))
-    ponder_thread.start()
-    return ponder_thread, ponder_move.uci()
-
-
-def get_pondering_results(ponder_thread, ponder_uci, game, board, engine):
-    if ponder_thread is None:
-        return None, None
-
-    move_uci = board.move_stack[-1].uci()
-    if ponder_uci == move_uci:
-        engine.ponderhit()
-        ponder_thread.join()
-        return ponder_results[game.id]
-    else:
-        engine.stop()
-        ponder_thread.join()
-        return None, None
+    return engine.search_with_ponder(board, wtime, btime, game.state["winc"], game.state["binc"], ponder)
 
 
 def fake_thinking(config, board, game):


### PR DESCRIPTION
The meaning of the ponder parameter of python-chess engine methods that
start searches has changed since the upgrade. Before, ponder=True would mean
that the current search was a pondering search. Now, ponder=True means
the engine should start pondering after choosing a move. Starting
pondering is handled by the python-chess library, so all pondering code
has been removed.

UCI engines will not receive a ponderhit command when their ponder
move is played by the opponent. They will only receive a stop command
followed by the next go command.

This should fix the issue discussed in #280.