### PR TITLE
From Position castling fix

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -292,7 +292,7 @@ def setup_board(game):
     if game.variant_name.lower() == "chess960":
         board = chess.Board(game.initial_fen, chess960=True)
     elif game.variant_name == "From Position":
-        board = chess.Board(game.initial_fen)
+        board = chess.Board(game.initial_fen, chess960=True) # Assumes the engine allows chess960 since castling is handled the chess960 way no matter what.
     else:
         VariantBoard = find_variant(game.variant_name)
         board = VariantBoard()


### PR DESCRIPTION
This fix is to address the From Position game mode that will break whenever a player castles. Lichess handles From Position the same as chess960 so it makes sense to tell the engine the same.
See [issue #234](https://github.com/ShailChoksi/lichess-bot/issues/234) for more info.