### PR TITLE
Personalise `!name`  command

### DIFF
--- a/conversation.py
+++ b/conversation.py
@@ -25,7 +25,8 @@ class Conversation:
             game.ping(60, 120)
             self.send_reply(line, "Waiting 60 seconds...")
         elif cmd == "name":
-            self.send_reply(line, "{} (lichess-bot v{})".format(self.engine.name(), self.version))
+            name = game.me.name
+            self.send_reply(line, "{} running {} (lichess-bot v{})".format(name, self.engine.name(), self.version))
         elif cmd == "howto":
             self.send_reply(line, "How to run your own bot: Check out 'Lichess Bot API'")
         elif cmd == "eval" and line.room == "spectator":


### PR DESCRIPTION
I have personalised to `!name`  command. 

Earlier on typing `!name`  in chat room, the reply given was :
`{engine name} (lichess-bot v1.2.0)`
example:
`Stockfish 13 (lichess-bot v1.2.0)`

Now to command will give the output (reply) : 
`{bot account name} running {engine name} (lichess-bot v1.2.0)`
example:
`YoBot_v2 running Stockfish 13 (lichess-bot v1.2.0)`