### PR TITLE
Regression fix: Disable pondering after first move

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -39,8 +39,9 @@ class EngineWrapper:
     def set_time_control(self, game):
         pass
 
-    def first_search(self, board, movetime, ponder):
-        return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder)
+    def first_search(self, board, movetime):
+        # No pondering after the first move since a different clock is used afterwards.
+        return self.search(board, chess.engine.Limit(time=movetime // 1000), False)
 
     def search_with_ponder(self, board, wtime, btime, winc, binc, ponder):
         pass

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -186,7 +186,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
                     best_move = get_book_move(board, polyglot_cfg)
                     if best_move is None:
                         if len(board.move_stack) < 2:
-                            best_move = choose_first_move(engine, board, is_uci_ponder)
+                            best_move = choose_first_move(engine, board)
                         else:
                             best_move = choose_move(engine, board, game, is_uci_ponder, start_time, move_overhead)
                     li.make_move(game.id, best_move)
@@ -218,11 +218,11 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     control_queue.put_nowait({"type": "local_game_done"})
 
 
-def choose_first_move(engine, board, ponder):
+def choose_first_move(engine, board):
     # need to hardcode first movetime (10000 ms) since Lichess has 30 sec limit.
     search_time = 10000
     logger.info("Searching for time {}".format(search_time))
-    return engine.first_search(board, search_time, ponder)
+    return engine.first_search(board, search_time)
 
 
 def get_book_move(board, polyglot_cfg):


### PR DESCRIPTION
Because the first move on lichess uses a different clock than the rest
of the game, engines cannot ponder after the first move because the
python-chess library sets the clock for pondering to be the same as the
move. After black's first move, it will think it has 10 seconds to
ponder no matter how short the time control and no matter how little
time white takes for its second move.

This was a mistake on my part introduced in the refactoring.