### PR TITLE
Fix Windows logging issues

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -13,6 +13,7 @@ import logging_pool
 import signal
 import time
 import backoff
+import sys
 from config import load_config
 from conversation import Conversation, ChatLine
 from functools import partial
@@ -85,10 +86,11 @@ def logging_listener_proc(queue, configurer, level, log_filename):
 
 
 def game_logging_configurer(queue, level):
-    h = logging.handlers.QueueHandler(queue)
-    root = logging.getLogger()
-    root.addHandler(h)
-    root.setLevel(level)
+    if sys.platform == 'win32':
+        h = logging.handlers.QueueHandler(queue)
+        root = logging.getLogger()
+        root.addHandler(h)
+        root.setLevel(level)
 
 
 def start(li, user_profile, engine_factory, config, logging_level, log_filename):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -86,6 +86,7 @@ def game_logging_configurer(queue, level):
     if sys.platform == 'win32':
         h = logging.handlers.QueueHandler(queue)
         root = logging.getLogger()
+        root.handlers.clear()
         root.addHandler(h)
         root.setLevel(level)
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -322,7 +322,8 @@ def fake_thinking(config, board, game):
 
 
 def print_move_number(board):
-    logger.info("\nmove: {}".format(len(board.move_stack) // 2 + 1))
+    logger.info("")
+    logger.info("move: {}".format(len(board.move_stack) // 2 + 1))
 
 
 def setup_board(game):


### PR DESCRIPTION
This should fix #290.

Using the multiprocessing library in Windows is different from Linux in that explicit structures have to be used to pass information (log entries in this case) between processes. With these changes, Windows and Linux should have identical behavior when it comes to logging.