### PR TITLE
Delete unused ponder variable

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -138,9 +138,6 @@ def start(li, user_profile, engine_factory, config):
     control_stream.join()
 
 
-ponder_results = {}
-
-
 @backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)
 def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue):
     response = li.get_game_stream(game_id)


### PR DESCRIPTION
This variable was leftover from removing all pondering code due to the
python-chess upgrade (#287).