### PR TITLE
Upgrade to python-chess 1.5.0

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -151,7 +151,6 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     game = model.Game(initial_state, user_profile["username"], li.baseUrl, config.get("abort_time", 20))
     engine = engine_factory()
     engine.get_opponent_info(game)
-    engine.set_time_control(game)
     conversation = Conversation(game, engine, li, __version__, challenge_queue)
 
     logger.info("+++ {}".format(game))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2020.12.05
 chardet==4.0.0
 idna==2.10
-chess==1.4.0
+chess==1.5.0
 PyYAML>=5.4.1
 requests>=2.25.1
 urllib3==1.26.3


### PR DESCRIPTION
New features and fixes in latest chess library that are relevant to
lichess-bot:

- UCI pondering reimplemented so that `ponderhit` is sent when the
  pondered move is played instead of `stop`.
- UCI `go ponder` command now includes full move list instead of
  an FEN and the last move and ponder move.
- Xboard engines get correct clock commands.(`level`) from library.
  This simplifies code in engine_wrapper.py.
- Xboard engine feature `usermove` implemented and accepted.

One possible annoyance: Xboard engines will be sent `level` command
before every move. If desired, this can be worked around.

Note: It is important to merge PR #293 along with this PR. UCI pondering
assumes that the clock has not changed. As it is now, a UCI engine could
lose up to ten seconds on its second move if the ponder move is played by
the opponent.