### PR TITLE
Manage dependency versions using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
GitHub's native Dependabot integration can manage dependency versions when security etc. patches become available.

This will integrate dependabot to send a PR (Pull Request) to this repository whenever one of the dependencies in the requirements.txt file updates. This PR can either be accepted or declined based on the owners choice. Might not be useful for updating dependencies like python chess, but will help in automatic updating other dependencies easily.