### PR TITLE
Put Active Correspondence Games into Queue on Startup

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -230,7 +230,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     correspondence_move_time = correspondence_cfg.get("move_time", 60) * 1000
 
     if is_correspondence and skip_correspondence:
-        logger.info("--- Skip {}".format(game.url()))
+        logger.info("--- Skiping {}".format(game.url()))
         game_queue.put(game_id)
         control_queue.put_nowait({"type": "local_game_done"})
         return

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -172,8 +172,10 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
                     pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
 
-            if event["type"] == "correspondence_ping" or (event["type"] == "local_game_done" and not wait_for_correspondence_ping):
-                if event["type"] == "correspondence_ping" and wait_for_correspondence_ping:
+            is_correspondence_ping = event["type"] == "correspondence_ping" 
+            is_local_game_done = event["type"] == "local_game_done" 
+            if is_correspondence_ping or (is_local_game_done and not wait_for_correspondence_ping):
+                if is_correspondence_ping and wait_for_correspondence_ping:
                     correspondence_queue.put("")
 
                 wait_for_correspondence_ping = False
@@ -181,12 +183,16 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     game_id = correspondence_queue.get()
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
-                        wait_for_correspondence_ping = True
-                        break
-                    else:
-                        busy_processes += 1
-                        logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
+                        if is_correspondence_ping and not correspondence_queue.empty():
+                            correspondence_queue.put("")
+                            continue
+                        else:
+                            wait_for_correspondence_ping = True
+                            break
+
+                    busy_processes += 1
+                    logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
+                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
 
             while ((queued_processes + busy_processes) < max_games and challenge_queue):  # keep processing the queue until empty or max_games is reached
                 chlng = challenge_queue.pop(0)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -162,6 +162,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
                 if game_id in startup_correspondence_games:
+                    logger.info("--- Enqueue {}".format(config["url"] + game_id))
                     correspondence_queue.put(game_id)
                     startup_correspondence_games.remove(game_id)
                 else:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -164,8 +164,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                 if busy_processes >= max_games:
                     game_start_queue.put(game_id)
                 else:
-                    # skip correspondence games if this gameStart is from
-                    # the initial connection to lichess
+                    # skip correspondence games if this gameStart is from the initial connection to lichess
                     skip_correspondence = queued_processes == 0
                     if queued_processes > 0:
                         queued_processes -= 1

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -110,8 +110,8 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
     correspondence_checkin_period = correspondence_cfg.get("checkin_period", 600)
     correspondence_pinger = multiprocessing.Process(target=do_correspondence_ping, args=[control_queue, correspondence_checkin_period])
     correspondence_pinger.start()
-    correspondence_queue = manager.Queue()
-    correspondence_queue.put("")
+    game_queue = manager.Queue()
+    game_queue.put("")
     wait_for_correspondence_ping = False
     busy_processes = 0
     queued_processes = 0
@@ -160,7 +160,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
                 if (busy_processes + queued_processes) >= max_games:
-                    correspondence_queue.put(game_id)
+                    game_queue.put(game_id)
                 else:
                     if queued_processes <= 0:
                         logger.debug("Something went wrong. Game is starting and we don't have a queued process")
@@ -168,15 +168,15 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                         queued_processes -= 1
                     busy_processes += 1
                     logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
+                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, game_queue, logging_queue, game_logging_configurer, logging_level])
 
             if event["type"] == "correspondence_ping" or (event["type"] == "local_game_done" and not wait_for_correspondence_ping):
                 if event["type"] == "correspondence_ping" and wait_for_correspondence_ping:
-                    correspondence_queue.put("")
+                    game_queue.put("")
 
                 wait_for_correspondence_ping = False
                 while (busy_processes + queued_processes) < max_games:
-                    game_id = correspondence_queue.get()
+                    game_id = game_queue.get()
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
                         wait_for_correspondence_ping = True
@@ -184,7 +184,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     else:
                         busy_processes += 1
                         logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
+                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, game_queue, logging_queue, game_logging_configurer, logging_level])
 
             while ((queued_processes + busy_processes) < max_games and challenge_queue):  # keep processing the queue until empty or max_games is reached
                 chlng = challenge_queue.pop(0)
@@ -210,7 +210,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
 
 
 @backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)
-def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, logging_configurer, logging_level):
+def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, game_queue, logging_queue, logging_configurer, logging_level):
     logging_configurer(logging_queue, logging_level)
     logger = logging.getLogger(__name__)
 
@@ -300,7 +300,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
     if is_correspondence and not is_game_over(game):
         logger.info("--- Disconnecting from {}".format(game.url()))
-        correspondence_queue.put(game_id)
+        game_queue.put(game_id)
     else:
         logger.info("--- {} Game over".format(game.url()))
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -183,16 +183,15 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     game_id = correspondence_queue.get()
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
-                        if is_correspondence_ping and not correspondence_queue.empty():
+                        if is_correspondence_ping and correspondence_queue:
                             correspondence_queue.put("")
-                            continue
                         else:
                             wait_for_correspondence_ping = True
                             break
-
-                    busy_processes += 1
-                    logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
+                    else:
+                        busy_processes += 1
+                        logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
+                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
 
             while ((queued_processes + busy_processes) < max_games and challenge_queue):  # keep processing the queue until empty or max_games is reached
                 chlng = challenge_queue.pop(0)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -110,10 +110,10 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
     correspondence_checkin_period = correspondence_cfg.get("checkin_period", 600)
     correspondence_pinger = multiprocessing.Process(target=do_correspondence_ping, args=[control_queue, correspondence_checkin_period])
     correspondence_pinger.start()
-    game_queue = manager.Queue()
-    game_queue.put("")
+    correspodence_queue = manager.Queue()
+    correspodence_queue.put("")
+    game_start_queue =  manager.Queue()
     wait_for_correspondence_ping = False
-    skip_correspondence = 2
 
     busy_processes = 0
     queued_processes = 0
@@ -162,33 +162,33 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
                 if busy_processes >= max_games:
-                    game_queue.put(game_id)
+                    game_start_queue.put(game_id)
                 else:
-                    if queued_processes <= 0:
-                        logger.debug("Something went wrong. Game is starting and we don't have a queued process")
-                    else:
+                    # skip correspondence games if this gameStart is from
+                    # the initial connection to lichess
+                    skip_correspondence = queued_processes == 0
+                    if queued_processes > 0:
                         queued_processes -= 1
                     busy_processes += 1
                     logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, game_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
+                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspodence_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
 
             if event["type"] == "correspondence_ping" or (event["type"] == "local_game_done" and not wait_for_correspondence_ping):
                 if event["type"] == "correspondence_ping" and wait_for_correspondence_ping:
-                    game_queue.put("")
+                    correspodence_queue.put("")
 
                 wait_for_correspondence_ping = False
                 while (busy_processes + queued_processes) < max_games:
-                    game_id = game_queue.get()
+                    skip_correspondence = not game_start_queue.empty();
+                    game_id = game_start_queue.get() if not game_start_queue.empty() else correspodence_queue.get()
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
                         wait_for_correspondence_ping = True
-                        if skip_correspondence:
-                            skip_correspondence -= 1
                         break
                     else:
                         busy_processes += 1
                         logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, game_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
+                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspodence_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
 
             while ((queued_processes + busy_processes) < max_games and challenge_queue):  # keep processing the queue until empty or max_games is reached
                 chlng = challenge_queue.pop(0)
@@ -214,7 +214,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
 
 
 @backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)
-def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, game_queue, logging_queue, logging_configurer, logging_level, skip_correspondence):
+def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspodence_queue, logging_queue, logging_configurer, logging_level, skip_correspondence):
     logging_configurer(logging_queue, logging_level)
     logger = logging.getLogger(__name__)
 
@@ -231,7 +231,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
     if is_correspondence and skip_correspondence:
         logger.info("--- Skiping {}".format(game.url()))
-        game_queue.put(game_id)
+        correspodence_queue.put(game_id)
         control_queue.put_nowait({"type": "local_game_done"})
         return
 
@@ -311,7 +311,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
     if is_correspondence and not is_game_over(game):
         logger.info("--- Disconnecting from {}".format(game.url()))
-        game_queue.put(game_id)
+        correspodence_queue.put(game_id)
     else:
         logger.info("--- {} Game over".format(game.url()))
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -110,8 +110,8 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
     correspondence_checkin_period = correspondence_cfg.get("checkin_period", 600)
     correspondence_pinger = multiprocessing.Process(target=do_correspondence_ping, args=[control_queue, correspondence_checkin_period])
     correspondence_pinger.start()
-    correspodence_queue = manager.Queue()
-    correspodence_queue.put("")
+    correspondence_queue = manager.Queue()
+    correspondence_queue.put("")
     game_start_queue =  manager.Queue()
     wait_for_correspondence_ping = False
 
@@ -170,16 +170,16 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                         queued_processes -= 1
                     busy_processes += 1
                     logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspodence_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
+                    pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
 
             if event["type"] == "correspondence_ping" or (event["type"] == "local_game_done" and not wait_for_correspondence_ping):
                 if event["type"] == "correspondence_ping" and wait_for_correspondence_ping:
-                    correspodence_queue.put("")
+                    correspondence_queue.put("")
 
                 wait_for_correspondence_ping = False
                 while (busy_processes + queued_processes) < max_games:
                     skip_correspondence = not game_start_queue.empty();
-                    game_id = game_start_queue.get() if not game_start_queue.empty() else correspodence_queue.get()
+                    game_id = game_start_queue.get() if not game_start_queue.empty() else correspondence_queue.get()
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
                         wait_for_correspondence_ping = True
@@ -187,7 +187,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     else:
                         busy_processes += 1
                         logger.info("--- Process Used. Total Queued: {}. Total Used: {}".format(queued_processes, busy_processes))
-                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspodence_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
+                        pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level, skip_correspondence])
 
             while ((queued_processes + busy_processes) < max_games and challenge_queue):  # keep processing the queue until empty or max_games is reached
                 chlng = challenge_queue.pop(0)
@@ -213,7 +213,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
 
 
 @backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)
-def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspodence_queue, logging_queue, logging_configurer, logging_level, skip_correspondence):
+def play_game(li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, logging_configurer, logging_level, skip_correspondence):
     logging_configurer(logging_queue, logging_level)
     logger = logging.getLogger(__name__)
 
@@ -230,7 +230,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
     if is_correspondence and skip_correspondence:
         logger.info("--- Skiping {}".format(game.url()))
-        correspodence_queue.put(game_id)
+        correspondence_queue.put(game_id)
         control_queue.put_nowait({"type": "local_game_done"})
         return
 
@@ -310,7 +310,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
     if is_correspondence and not is_game_over(game):
         logger.info("--- Disconnecting from {}".format(game.url()))
-        correspodence_queue.put(game_id)
+        correspondence_queue.put(game_id)
     else:
         logger.info("--- {} Game over".format(game.url()))
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -113,7 +113,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
     game_queue = manager.Queue()
     game_queue.put("")
     wait_for_correspondence_ping = False
-    skip_correspondence = True
+    skip_correspondence = 2
 
     busy_processes = 0
     queued_processes = 0
@@ -182,7 +182,8 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
                         wait_for_correspondence_ping = True
-                        skip_correspodence = False
+                        if skip_correspodnece:
+                            skip_correspondence -= 1
                         break
                     else:
                         busy_processes += 1

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -182,7 +182,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
                         wait_for_correspondence_ping = True
-                        if skip_correspodnece:
+                        if skip_correspondence:
                             skip_correspondence -= 1
                         break
                     else:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -159,7 +159,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                         pass
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
-                if (busy_processes + queued_processes) >= max_games:
+                if busy_processes >= max_games:
                     game_queue.put(game_id)
                 else:
                     if queued_processes <= 0:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -113,7 +113,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
     game_queue = manager.Queue()
     game_queue.put("")
     wait_for_correspondence_ping = False
-    skip_correspondence = False
+    skip_correspondence = True
 
     busy_processes = 0
     queued_processes = 0
@@ -163,7 +163,6 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                 game_id = event["game"]["id"]
                 if busy_processes >= max_games:
                     game_queue.put(game_id)
-                    skip_correspondence = True
                 else:
                     if queued_processes <= 0:
                         logger.debug("Something went wrong. Game is starting and we don't have a queued process")


### PR DESCRIPTION
This pr fixes the issue in #339 which caused correspondence games that could not be given a thread at startup to be forgotten by the bot and for the bot to never move in them. It does so by pushing game ids the main thread receives through a gameStart event and can't start a process for into the game queue. This behavior works with normal games as well, because games started from the queue are started in exactly the same way as from a gameStart event.