### PR TITLE
Prioritize Accepting Challenges Over Checking for Moves in Correspondence Games

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -167,7 +167,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                 game_id = event["game"]["id"]
                 pool.apply_async(play_game, [li, game_id, control_queue, engine_factory, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level])
 
-            if event["type"] == "correspondence_ping" or (event["type"] == "local_game_done" and not wait_for_correspondence_ping):
+            if (event["type"] == "correspondence_ping" or (event["type"] == "local_game_done" and not wait_for_correspondence_ping)) and not challenge_queue:
                 if event["type"] == "correspondence_ping" and wait_for_correspondence_ping:
                     correspondence_queue.put("")
 


### PR DESCRIPTION
In the current build (and after #341), bots with >50 correspondence games may take tens of minutes to accept challenges because processing the correspondence queue takes priority over accepting challenges. This pr addresses this by only allowing the correspondence queue to be processed when there are no challenges queued, so that challenges are processed as soon as the bot has a free thread. I do not think that this should be configurable because even in correspondence-focused bots, it is good to accept challenges for correspondence games quickly.