### PR TITLE
Inherit `search_with_ponder` from `EngineWrapper`

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -57,7 +57,7 @@ class GameEnding:
 
 class EngineWrapper:
     def __init__(self, commands, options, stderr):
-        self.go_commands = options.pop("go_commands", {}) or {}
+        pass
 
     def search_for(self, board, movetime, ponder):
         return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder)

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -57,7 +57,7 @@ class GameEnding:
 
 class EngineWrapper:
     def __init__(self, commands, options, stderr):
-        pass
+        self.go_commands = options.pop("go_commands", {}) or {}
 
     def search_for(self, board, movetime, ponder):
         return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder)

--- a/strategies.py
+++ b/strategies.py
@@ -44,8 +44,9 @@ class MinimalEngine(EngineWrapper):
     however you can also change other methods like
     `notify`, `first_search`, `get_time_control`, etc.
     """
-    def __init__(self, *args, name=None):
-        super().__init__(*args)
+    def __init__(self, commands, options, stderr, name=None):
+        super().__init__(commands, options, stderr)
+        self.go_commands = options.pop("go_commands", {}) or {}
 
         self.name = self.__class__.__name__ if name is None else name
 

--- a/strategies.py
+++ b/strategies.py
@@ -52,15 +52,18 @@ class MinimalEngine(EngineWrapper):
         self.last_move_info = []
         self.engine = FillerEngine(self, name=self.name)
 
-    def search_with_ponder(self, board, wtime, btime, winc, binc, ponder):
-        timeleft = 0
-        if board.turn:
-            timeleft = wtime
-        else:
-            timeleft = btime
-        return self.search(board, timeleft, ponder)
-
     def search(self, board, timeleft, ponder):
+        """
+        This method is meant to be overridden,
+        it defines engines' implementation.
+        
+        Parameters
+        ----------
+        board : chess.Board
+        timeleft : chess.engine.Limit
+        ponder : boolean
+           Whether to think on opponent's time
+        """
         raise NotImplementedError("The search method is not implemented")
 
     def notify(self, method_name, *args, **kwargs):

--- a/strategies.py
+++ b/strategies.py
@@ -58,12 +58,14 @@ class MinimalEngine(EngineWrapper):
         This method is meant to be overridden,
         it defines engines' implementation.
         
-        Parameters
-        ----------
+        --- Parameters ---
         board : chess.Board
         timeleft : chess.engine.Limit
         ponder : boolean
            Whether to think on opponent's time
+
+        --- Returns ---
+        An instance of `chess.engine.PlayResult`
         """
         raise NotImplementedError("The search method is not implemented")
 


### PR DESCRIPTION
Nowadays `search_with_ponder` is outdated.

____
The inherited `search_with_ponder` requires `go_commands` be defined, so set that too