### PR TITLE
Fix AttributeError

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1,4 +1,5 @@
 import os
+import chess
 import chess.engine
 import backoff
 import subprocess

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1,5 +1,4 @@
 import os
-import chess
 import chess.engine
 import backoff
 import subprocess
@@ -58,7 +57,7 @@ class GameEnding:
 
 class EngineWrapper:
     def __init__(self, commands, options, stderr):
-        pass
+        self.go_commands = options.pop("go_commands", {}) or {}
 
     def search_for(self, board, movetime, ponder):
         return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder)
@@ -68,7 +67,8 @@ class EngineWrapper:
         return self.search(board, chess.engine.Limit(time=movetime // 1000), False)
 
     def search_with_ponder(self, board, wtime, btime, winc, binc, ponder):
-        movetime = wtime if board.turn is chess.WHITE else btime
+        cmds = self.go_commands
+        movetime = cmds.get("movetime")
         if movetime is not None:
             movetime = float(movetime) / 1000
         time_limit = chess.engine.Limit(white_clock=wtime / 1000,

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -67,8 +67,7 @@ class EngineWrapper:
         return self.search(board, chess.engine.Limit(time=movetime // 1000), False)
 
     def search_with_ponder(self, board, wtime, btime, winc, binc, ponder):
-        cmds = self.go_commands
-        movetime = cmds.get("movetime")
+        movetime = wtime if board.turn is chess.WHITE else btime
         if movetime is not None:
             movetime = float(movetime) / 1000
         time_limit = chess.engine.Limit(white_clock=wtime / 1000,


### PR DESCRIPTION
UCI Engines don't have the property `go_commands`, so this gets an attribute error:

2021-06-15 22:12:42,151: move: 2
2021-06-15 22:12:42,151: Searching for wtime 231030 btime 240000
2021-06-15 22:12:42,152: Backing off play_game(...) for 4.1s (AttributeError: 'Thousandatom' object has no attribute 'go_commands')
2021-06-15 22:12:46,631: +++ https://lichess.org/9scg1Sa3/white Blitz vs AI level 1
2021-06-15 22:12:46,633: --- https://lichess.org/9scg1Sa3/white Game over