### PR TITLE
Handle unexpected responses from lichess.org without a `type` field

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -128,10 +128,10 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                 continue
 
             if event.get("type") is None:
-                logger.error("Unable to handle response from lichess.org:")
-                logger.error(event)
+                logger.warning("Unable to handle response from lichess.org:")
+                logger.warning(event)
                 if event.get("error") == "Missing scope":
-                    logger.error('Please check that the API access token for your bot has the scope "Play games with the bot API".')
+                    logger.warning('Please check that the API access token for your bot has the scope "Play games with the bot API".')
                 continue
             
             if event["type"] == "terminated":

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -132,8 +132,9 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                 logger.error(event)
                 if event.get("error") == "Missing scope":
                     logger.error('Please check that the API access token for your bot has the scope "Play games with the bot API".')
-                    continue
-            elif event["type"] == "terminated":
+                continue
+            
+            if event["type"] == "terminated":
                 break
             elif event["type"] == "local_game_done":
                 busy_processes -= 1

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -126,7 +126,14 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                 event = control_queue.get()
             except InterruptedError:
                 continue
-            if event["type"] == "terminated":
+
+            if event.get("type") is None:
+                logger.error("Unable to handle response from lichess.org:")
+                logger.error(event)
+                if event.get("error") == "Missing scope":
+                    logger.error('Please check that the API access token for your bot has the scope "Play games with the bot API".')
+                    continue
+            elif event["type"] == "terminated":
                 break
             elif event["type"] == "local_game_done":
                 busy_processes -= 1


### PR DESCRIPTION
There are several open bug reports that have the error message

    Traceback (most recent call last):
      File "lichess-bot.py", line 131, in start
        if event["type"] == "terminated":
    KeyError: 'type'

These include #188, #197, #201, #224, #245, and most recently #311.

This commit checks that the incoming message has a `type` field
and, if it does not, prints an error message including the full
response from lichess. If the error is "Missing scope", the printed
message will include the warning that the API access token does
not have the permission to play as a bot.

I considered terminating lichess-bot when encountering this error,
but some of the bug reports mentioned that this error was
intermittent, so lichess-bot will remain connected to lichess.org.