### PR TITLE
Don’t ignore `/engines/README.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 config.yml
 __pycache__
 /engines/*
-!/engines/README.md


### PR DESCRIPTION
While it completely makes sense to add `.gitignore` the engine so that when testing locally to make a pull request the engine used for testing doesn’t get added, but the README.md file in the `engines` dir doesn’t require to be `.gitignore`-d. This PR hence removes the file `/engines/README.md` from the `.gitignore` file.

No real functional change as such, just a correction.