### PR TITLE
Remove word `bot` from conversation

### DIFF
--- a/conversation.py
+++ b/conversation.py
@@ -28,7 +28,7 @@ class Conversation:
             name = game.me.name
             self.send_reply(line, "{} running {} (lichess-bot v{})".format(name, self.engine.name(), self.version))
         elif cmd == "howto":
-            self.send_reply(line, "How to run your own bot: Check out 'Lichess Bot API'")
+            self.send_reply(line, "How to run: Check out 'Lichess Bot API'")
         elif cmd == "eval" and line.room == "spectator":
             stats = self.engine.get_stats()
             self.send_reply(line, ", ".join(stats))


### PR DESCRIPTION
The word `bot` is part of lichess’ shutup dictionary. Every time a word from that dictionary is used, it is sent as a report.

https://github.com/ornicar/lila/blob/master/modules/shutup/src/main/Dictionary.scala#L36