### PR TITLE
Add ChessDB opening book and online endgame TBs

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -26,6 +26,13 @@ engine:                      # Engine settings.
     move_quality: "good"     # One of "all", "good", "best"
     min_depth: 20            # Only for move_quality: "best"
     contribute: true
+  lichess_cloud_analysis:
+    enabled: false
+    min_time: 20
+    move_quality: "good"     # One of "good", "best"
+    max_score_difference: 50 # Only for move_quality: "good". The maximum score difference (in cp) between the best move and the other moves.
+    min_depth: 20
+    min_knodes: 0
   online_egtb:
     enabled: false
     min_time: 20

--- a/config.yml.default
+++ b/config.yml.default
@@ -20,25 +20,26 @@ engine:                      # Engine settings.
     min_weight: 1            # Does not select moves with weight below min_weight (min 0, max: 65535).
     selection: "weighted_random" # Move selection is one of "weighted_random", "uniform_random" or "best_move" (but not below the min_weight in the 2nd and 3rd case).
     max_depth: 8             # Half move max depth.
-  chessdb_book:
-    enabled: false
-    min_time: 20
-    move_quality: "good"     # One of "all", "good", "best"
-    min_depth: 20            # Only for move_quality: "best"
-    contribute: true
-  lichess_cloud_analysis:
-    enabled: false
-    min_time: 20
-    move_quality: "good"     # One of "good", "best"
-    max_score_difference: 50 # Only for move_quality: "good". The maximum score difference (in cp) between the best move and the other moves.
-    min_depth: 20
-    min_knodes: 0
-  online_egtb:
-    enabled: false
-    min_time: 20
-    max_pieces: 7
-    source: "lichess"        # One of "lichess", "chessdb"
-    move_quality: "best"     # One of "good", "best"
+  online_moves:
+    chessdb_book:
+      enabled: false
+      min_time: 20
+      move_quality: "good"     # One of "all", "good", "best"
+      min_depth: 20            # Only for move_quality: "best"
+      contribute: true
+    lichess_cloud_analysis:
+      enabled: false
+      min_time: 20
+      move_quality: "good"     # One of "good", "best"
+      max_score_difference: 50 # Only for move_quality: "good". The maximum score difference (in cp) between the best move and the other moves.
+      min_depth: 20
+      min_knodes: 0
+    online_egtb:
+      enabled: false
+      min_time: 20
+      max_pieces: 7
+      source: "lichess"        # One of "lichess", "chessdb"
+      move_quality: "best"     # One of "good", "best"
 # engine_options:            # Any custom command line params to pass to the engine.
 #   cpuct: 3.1
   homemade_options:

--- a/config.yml.default
+++ b/config.yml.default
@@ -20,6 +20,18 @@ engine:                      # Engine settings.
     min_weight: 1            # Does not select moves with weight below min_weight (min 0, max: 65535).
     selection: "weighted_random" # Move selection is one of "weighted_random", "uniform_random" or "best_move" (but not below the min_weight in the 2nd and 3rd case).
     max_depth: 8             # Half move max depth.
+  chessdb_book:
+    enabled: false
+    min_time: 20
+    move_quality: "good"     # One of "all", "good", "best"
+    min_depth: 20            # Only for move_quality: "best"
+    contribute: true
+  online_egtb:
+    enabled: false
+    min_time: 20
+    max_pieces: 7
+    source: "lichess"        # One of "lichess", "chessdb"
+    move_quality: "best"     # One of "good", "best"
 # engine_options:            # Any custom command line params to pass to the engine.
 #   cpuct: 3.1
   homemade_options:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -438,7 +438,7 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
                     move = random_move["uci"]
                     wdl = random_move["wdl"] * -1
                     dtz = random_move["dtz"] * -1
-                    dtm = data["moves"][0]["dtm"]
+                    dtm = random_move["dtm"]
                     if dtm:
                         dtm *= -1
                 if wdl is not None:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -401,13 +401,13 @@ def get_chessdb_move(li, board, game, chessdb_cfg):
             if data["status"] == "ok":
                 move = data["move"]
                 logger.info("Got move {} from chessdb.cn".format(move))
-    except:
+    except Exception:
         pass
 
     if chessdb_cfg.get("contribute", True):
         try:
             li.api_get(f"http://www.chessdb.cn/cdb.php?action=queue&board={board.fen()}&json=1")
-        except:
+        except Exception:
             pass
 
     return move
@@ -448,7 +448,7 @@ def get_lichess_cloud_move(li, board, game, lichess_cloud_cfg):
                     move = pv["moves"].split()[0]
                     score = pv["cp"]
                     logger.info("Got move {} from lichess cloud analysis (depth: {}, score: {}, knodes: {})".format(move, depth, score, knodes))
-    except:
+    except Exception:
         pass
 
     return None
@@ -519,7 +519,7 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
                     move = random_move["uci"]
                     logger.info("Got move {} from chessdb.cn (wdl: {})".format(move, score_to_wdl(score)))
                     return move
-    except:
+    except Exception:
         pass
 
     return None

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -242,9 +242,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     move_overhead = config.get("move_overhead", 1000)
     delay_seconds = config.get("rate_limiting_delay", 0)/1000
     polyglot_cfg = engine_cfg.get("polyglot", {})
-    chessdb_cfg = engine_cfg.get("chessdb_book", {})
-    lichess_cloud_cfg = engine_cfg.get("lichess_cloud_analysis", {})
-    online_egtb_cfg = engine_cfg.get("online_egtb", {})
+    online_moves_cfg = engine_cfg.get("online_moves", {})
 
     first_move = True
     correspondence_disconnect_time = 0
@@ -271,11 +269,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
                     best_move = get_book_move(board, polyglot_cfg)
                     if best_move is None:
-                        best_move = get_online_egtb_move(li, board, game, online_egtb_cfg)
-                    if best_move is None:
-                        best_move = get_chessdb_move(li, board, game, chessdb_cfg)
-                    if best_move is None:
-                        best_move = lichess_cloud_cfg(li, board, game, lichess_cloud_cfg)
+                        best_move = get_online_move(li, board, game, online_moves_cfg)
                     if best_move is None:
                         if len(board.move_stack) < 2:
                             best_move = choose_first_move(engine, board)
@@ -525,6 +519,18 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
         pass
 
     return None
+
+
+def get_online_move(li, board, game, online_moves_cfg):
+    online_egtb_cfg = online_moves_cfg.get("online_egtb", {})
+    chessdb_cfg = online_moves_cfg.get("chessdb_book", {})
+    lichess_cloud_cfg = online_moves_cfg.get("lichess_cloud_analysis", {})
+    best_move = get_online_egtb_move(li, board, game, online_egtb_cfg)
+    if best_move is None:
+        best_move = get_chessdb_move(li, board, game, chessdb_cfg)
+    if best_move is None:
+        best_move = get_lichess_cloud_move(li, board, game, lichess_cloud_cfg)
+    return best_move
 
 
 def choose_move(engine, board, game, ponder, start_time, move_overhead):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -418,6 +418,8 @@ def get_lichess_cloud_move(li, board, game, lichess_cloud_cfg):
     if not lichess_cloud_cfg.get("enabled", False) or game.state[f"{wb}time"] < lichess_cloud_cfg.get("min_time", 20) * 1000:
         return None
 
+    move = None
+    
     quality = lichess_cloud_cfg.get("move_quality", "best")
     multipv = 1 if quality == "best" else 5
     variant = "standard" if board.uci_variant == "chess" else board.uci_variant
@@ -451,7 +453,7 @@ def get_lichess_cloud_move(li, board, game, lichess_cloud_cfg):
     except Exception:
         pass
 
-    return None
+    return move
 
 
 def get_online_egtb_move(li, board, game, online_egtb_cfg):

--- a/lichess.py
+++ b/lichess.py
@@ -41,10 +41,11 @@ class Lichess:
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)
-    def api_get(self, path):
+    def api_get(self, path, raise_for_status=True):
         url = urljoin(self.baseUrl, path)
         response = self.session.get(url, timeout=2)
-        response.raise_for_status()
+        if raise_for_status:
+            response.raise_for_status()
         return response.json()
 
     @backoff.on_exception(backoff.constant,


### PR DESCRIPTION
A lot of engines have been using the ChessDB opening book (e.g. [BrainLearn](https://github.com/amchess/BrainLearn)) and I recently saw a chess engine ([weiss](https://github.com/TerjeKir/weiss)) use the online TBs. This will be like what was mentioned in #314 but without having to download the files.

We can also get EGTBs from chessdb.cn and not only from lichess but I am not sure if it is needed because lichess also has atomic and antichess but I added code also for chessdb because it may be faster for someone to get the move from chessdb instead of lichess.

I am not sure if the best place for them was in the engines section in config.yml but I put them there because the polyglot opening book section is also there. chessdb.cn has a 100000 rate limit per day (1.15 per second), so I don't think that anyone is going to hit that limit unless they are playing 0.5+0 for a whole day.