### PR TITLE
Allow setting API token in environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install -r requirements.txt
 - Create an account for your bot on [Lichess.org](https://lichess.org/signup)
 - NOTE: If you have previously played games on an existing account, you will not be able to use it as a bot account
 - Once your account has been created and you are logged in, [create a personal OAuth2 token](https://lichess.org/account/oauth/token/create?scopes[]=bot:play&description=lichess-bot) with the "Play as a bot" selected and add a description
-- A `token` e.g. `Xb0ddNrLabc0lGK2` will be displayed. Store this in `config.yml` as the `token` field
+- A `token` e.g. `Xb0ddNrLabc0lGK2` will be displayed. Store this in `config.yml` as the `token` field. You can also set the token in the environment variable `$LICHESS_BOT_TOKEN`.
 - NOTE: You won't see this token again on Lichess.
 
 

--- a/config.py
+++ b/config.py
@@ -14,6 +14,9 @@ def load_config(config_file):
             logger.error("There appears to be a syntax problem with your config.yml")
             raise e
 
+        if "LICHESS_BOT_TOKEN" in os.environ:
+            CONFIG["token"] = os.environ["LICHESS_BOT_TOKEN"]
+            
         # [section, type, error message]
         sections = [["token", str, "Section `token` must be a string wrapped in quotes."],
                     ["url", str, "Section `url` must be a string wrapped in quotes."],


### PR DESCRIPTION
This pull request allows the Lichess API token to be set in the environment variable `$LICHESS_BOT_TOKEN`.
If both `$LICHESS_BOT_TOKEN` and the config entry `token` exists,  the environment variable takes precedence.

As an example why this might be useful:
I am building a docker image containing lichess-bot, my chess engine and a config.yml from my repo in Gitlab CI on every release. I want to deploy this image to a server, but it would be a bad idea to include the API token in the repo or to build it into the image. Using an environment variable I can set the API token on my server.