### PR TITLE
Fix bug in draw offers due to lichess API change

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -381,7 +381,7 @@ def choose_move(engine, board, game, ponder, draw_offered, start_time, move_over
 
 
 def check_for_draw_offer(game):
-    return game.state[f'{game.opponent_color[0]}draw']
+    return game.state.get(f'{game.opponent_color[0]}draw', False)
 
 
 def fake_thinking(config, board, game):


### PR DESCRIPTION
While fixing the merge conflicts in PR #375, I discovered a bug in #327. Apparently, there's been a change to the lichess API where draw offers (`bdraw` and `wdraw` fields in game state) are not sent on the first move. This PR supplies the fix.

The same commit is also present in PR #375, but I thought it was important to fix this bug even if the greeting PR had to be delayed.