### PR TITLE
Resign or offer/accept draw based on score

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Besides the above, there are many possible options within `config.yml` for confi
 - `polyglot`: Tell lichess-bot whether your bot should use an opening book. Multiple books can be specified for each chess variant.
     - `enabled`: Whether to use the book at all.
     - `book`: A nested list of books. The next indented line should list a chess variant (`standard`, `3check`, `horde`, etc.) followed on succeeding indented lines with paths to the book files. See `config.yml.default` for examples.
-- `draw_or_resign`: This section allows your bot to resign or offer/accept draw based on the evaluation by the engine
+- `draw_or_resign`: This section allows your bot to resign or offer/accept draw based on the evaluation by the engine. XBoard engines can resign and offer/accept draw without this feature enabled.
     - `resign_enabled`: Whether the bot is allowed to resign based on the evaluation.
     - `resign_score`: The engine evaluation has to be less than or equal to `resign_score` for the bot to resign.
     - `resign_moves`: The evaluation has to be less than or equal to `resign_score` for `resign_moves` amount of moves for the bot to resign.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Besides the above, there are many possible options within `config.yml` for confi
 - `polyglot`: Tell lichess-bot whether your bot should use an opening book. Multiple books can be specified for each chess variant.
     - `enabled`: Whether to use the book at all.
     - `book`: A nested list of books. The next indented line should list a chess variant (`standard`, `3check`, `horde`, etc.) followed on succeeding indented lines with paths to the book files. See `config.yml.default` for examples.
+- `draw_or_resign`: This section allows your bot to resign or offer/accept draw based on the evaluation by the engine
+    - `resign_enabled`: Whether the bot is allowed to resign based on the evaluation.
+    - `resign_score`: The engine evaluation has to be less than or equal to `resign_score` for the bot to resign.
+    - `resign_moves`: The evaluation has to be less than or equal to `resign_score` for `resign_moves` amount of moves for the bot to resign.
+    - `offer_draw_enabled`: Whether the bot is allowed to offer/accept draw based on the evaluation.
+    - `offer_draw_score`: The absolute value of the engine evaluation has to be less than or equal to `offer_draw_score` for the bot to offer/accept draw.
+    - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
+    - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 - `online_moves`: This section gives your bot access to various online resources for choosing moves like opening books and endgame tablebases. This can be a supplement or a replacement for chess databases stored on your computer. There are three sections that correspond to three different online databases:
     1. `chessdb_book`: Consults a [Chinese chess position database](https://www.chessdb.cn/), which also hosts a xiangqi database.
     2. `lichess_cloud_analysis`: Consults [Lichess' own position analysis database](https://lichess.org/api#operation/apiCloudEval).

--- a/config.yml.default
+++ b/config.yml.default
@@ -20,17 +20,25 @@ engine:                      # Engine settings.
     min_weight: 1            # Does not select moves with weight below min_weight (min 0, max: 65535).
     selection: "weighted_random" # Move selection is one of "weighted_random", "uniform_random" or "best_move" (but not below the min_weight in the 2nd and 3rd case).
     max_depth: 8             # Half move max depth.
+  draw_or_resign:
+    resign_enabled: false
+    resign_score: -1000      # If the score is less than or equal to this value, we resign (in cp)
+    resign_moves: 3          # How many moves in a row the score has to be below the resign value
+    offer_draw_enabled: false
+    offer_draw_score: 0      # If the absolute value of the score is less than or equal to this value, we offer draw (in cp)
+    offer_draw_moves: 5      # How many moves in a row the score has to be below the draw value
+    offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to the value, we offer draw
   online_moves:
     chessdb_book:
       enabled: false
       min_time: 20
-      move_quality: "good"     # One of "all", "good", "best"
-      min_depth: 20            # Only for move_quality: "best"
+      move_quality: "good"   # One of "all", "good", "best"
+      min_depth: 20          # Only for move_quality: "best"
       contribute: true
     lichess_cloud_analysis:
       enabled: false
       min_time: 20
-      move_quality: "good"     # One of "good", "best"
+      move_quality: "good"   # One of "good", "best"
       max_score_difference: 50 # Only for move_quality: "good". The maximum score difference (in cp) between the best move and the other moves.
       min_depth: 20
       min_knodes: 0
@@ -38,8 +46,8 @@ engine:                      # Engine settings.
       enabled: false
       min_time: 20
       max_pieces: 7
-      source: "lichess"        # One of "lichess", "chessdb"
-      move_quality: "best"     # One of "good", "best"
+      source: "lichess"      # One of "lichess", "chessdb"
+      move_quality: "best"   # One of "good", "best"
 # engine_options:            # Any custom command line params to pass to the engine.
 #   cpuct: 3.1
   homemade_options:

--- a/config.yml.default
+++ b/config.yml.default
@@ -22,12 +22,12 @@ engine:                      # Engine settings.
     max_depth: 8             # Half move max depth.
   draw_or_resign:
     resign_enabled: false
-    resign_score: -1000      # If the score is less than or equal to this value, we resign (in cp)
+    resign_score: -1000      # If the score is less than or equal to this value, the bot resigns (in cp)
     resign_moves: 3          # How many moves in a row the score has to be below the resign value
     offer_draw_enabled: false
-    offer_draw_score: 0      # If the absolute value of the score is less than or equal to this value, we offer draw (in cp)
-    offer_draw_moves: 5      # How many moves in a row the score has to be below the draw value
-    offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to the value, we offer draw
+    offer_draw_score: 0      # If the absolute value of the score is less than or equal to this value, the bot offers/accepts draw (in cp)
+    offer_draw_moves: 5      # How many moves in a row the absolute value of the score has to be below the draw value
+    offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw
   online_moves:
     chessdb_book:
       enabled: false

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -14,7 +14,7 @@ def create_engine(config):
     engine_path = os.path.join(cfg["dir"], cfg["name"])
     engine_type = cfg.get("protocol")
     engine_options = cfg.get("engine_options")
-    draw_or_resign = cfg.get("draw_or_resign", {})
+    draw_or_resign = cfg.get("draw_or_resign") or {}
     commands = [engine_path]
     if engine_options:
         for k, v in engine_options.items():
@@ -65,6 +65,7 @@ class EngineWrapper:
     def __init__(self, commands, options, stderr, draw_or_resign):
         self.scores = []
         self.draw_or_resign = draw_or_resign
+        self.go_commands = options.pop("go_commands", {}) or {}
 
     def search_for(self, board, movetime, ponder, draw_offered):
         return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder, draw_offered)
@@ -156,7 +157,6 @@ class EngineWrapper:
 class UCIEngine(EngineWrapper):
     def __init__(self, commands, options, stderr, draw_or_resign):
         super().__init__(commands, options, stderr, draw_or_resign)
-        self.go_commands = options.pop("go_commands", {}) or {}
         self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=stderr)
         self.engine.configure(options)
         self.last_move_info = {}
@@ -179,7 +179,6 @@ class UCIEngine(EngineWrapper):
 class XBoardEngine(EngineWrapper):
     def __init__(self, commands, options, stderr, draw_or_resign):
         super().__init__(commands, options, stderr, draw_or_resign)
-        self.go_commands = options.pop("go_commands", {}) or {}
         self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=stderr)
         egt_paths = options.pop("egtpath", {}) or {}
         features = self.engine.protocol.features

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -66,6 +66,7 @@ class EngineWrapper:
         self.scores = []
         self.draw_or_resign = draw_or_resign
         self.go_commands = options.pop("go_commands", {}) or {}
+        self.last_move_info = {}
 
     def search_for(self, board, movetime, ponder, draw_offered):
         return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder, draw_offered)
@@ -159,7 +160,6 @@ class UCIEngine(EngineWrapper):
         super().__init__(commands, options, stderr, draw_or_resign)
         self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=stderr)
         self.engine.configure(options)
-        self.last_move_info = {}
 
     def stop(self):
         self.engine.protocol.send_line("stop")
@@ -186,7 +186,6 @@ class XBoardEngine(EngineWrapper):
         for egt_type in egt_types_from_engine:
             options[f"egtpath {egt_type}"] = egt_paths[egt_type]
         self.engine.configure(options)
-        self.last_move_info = {}
 
     def report_game_result(self, game, board):
         # Send final moves, if any, to engine

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -85,12 +85,15 @@ class EngineWrapper:
     def offer_draw_or_resign(self, result, board):
         if self.draw_or_resign.get('offer_draw_enabled', False) and len(self.scores) >= self.draw_or_resign.get('offer_draw_moves', 5):
             scores = self.scores[-self.draw_or_resign.get('offer_draw_moves', 5):]
-            if len(scores) == len(list(filter(lambda score: abs(score.relative.score(mate_score=40000)) <= self.draw_or_resign.get('offer_draw_score', 10), scores))) and len([board.piece_type_at(sq) for sq in chess.SQUARES if board.piece_type_at(sq)]) <= self.draw_or_resign.get('offer_draw_pieces', 10):
+            pieces_on_board = len([board.piece_type_at(sq) for sq in chess.SQUARES if board.piece_type_at(sq)])
+            scores_near_draw = lambda score: abs(score.relative.score(mate_score=40000)) <= self.draw_or_resign.get('offer_draw_score', 0)
+            if len(scores) == len(list(filter(scores_near_draw, scores))) and pieces_on_board <= self.draw_or_resign.get('offer_draw_pieces', 10):
                 result.draw_offered = True
 
         if self.draw_or_resign.get('resign_enabled', False) and len(self.scores) >= self.draw_or_resign.get('resign_moves', 3):
             scores = self.scores[-self.draw_or_resign.get('resign_moves', 3):]
-            if len(scores) == len(list(filter(lambda score: score.relative.score(mate_score=40000) <= self.draw_or_resign.get('resign_score', -1000), scores))):
+            scores_near_loss = lambda score: score.relative.score(mate_score=40000) <= self.draw_or_resign.get('resign_score', -1000)
+            if len(scores) == len(list(filter(scores_near_loss, scores))):
                 result.resigned = True
         return result
 

--- a/lichess.py
+++ b/lichess.py
@@ -66,8 +66,11 @@ class Lichess:
         return self.api_post(ENDPOINTS["upgrade"])
 
     def make_move(self, game_id, move):
-        return self.api_post(ENDPOINTS["move"].format(game_id, move.move),
-                             params={'offeringDraw': str(move.draw_offered).lower()})
+        if move.resigned:
+            return self.resign(game_id)
+        else:
+            return self.api_post(ENDPOINTS["move"].format(game_id, move.move),
+                                 params={'offeringDraw': str(move.draw_offered).lower()})
 
     def chat(self, game_id, room, text):
         payload = {'room': room, 'text': text}

--- a/lichess.py
+++ b/lichess.py
@@ -66,11 +66,8 @@ class Lichess:
         return self.api_post(ENDPOINTS["upgrade"])
 
     def make_move(self, game_id, move):
-        if move.resigned:
-            return self.resign(game_id)
-        else:
-            return self.api_post(ENDPOINTS["move"].format(game_id, move.move),
-                                 params={'offeringDraw': str(move.draw_offered).lower()})
+        return self.api_post(ENDPOINTS["move"].format(game_id, move.move),
+                             params={'offeringDraw': str(move.draw_offered).lower()})
 
     def chat(self, game_id, room, text):
         payload = {'room': room, 'text': text}

--- a/strategies.py
+++ b/strategies.py
@@ -57,7 +57,7 @@ class MinimalEngine(EngineWrapper):
             "name": self.engine_name
         }
 
-    def search(self, board, timeleft, ponder, draw_offered):
+    def search(self, board, time_limit, ponder, draw_offered):
         """
         The method to be implemented in your homemade engine
 

--- a/strategies.py
+++ b/strategies.py
@@ -47,7 +47,6 @@ class MinimalEngine(EngineWrapper):
     """
     def __init__(self, commands, options, stderr, draw_or_resign, name=None):
         super().__init__(commands, options, stderr, draw_or_resign)
-        self.go_commands = options.pop("go_commands", {}) or {}
 
         self.engine_name = self.__class__.__name__ if name is None else name
 

--- a/strategies.py
+++ b/strategies.py
@@ -50,7 +50,6 @@ class MinimalEngine(EngineWrapper):
 
         self.engine_name = self.__class__.__name__ if name is None else name
 
-        self.last_move_info = []
         self.engine = FillerEngine(self, name=self.name)
         self.engine.id = {
             "name": self.engine_name

--- a/strategies.py
+++ b/strategies.py
@@ -45,8 +45,8 @@ class MinimalEngine(EngineWrapper):
     however you can also change other methods like
     `notify`, `first_search`, `get_time_control`, etc.
     """
-    def __init__(self, commands, options, stderr, name=None):
-        super().__init__(commands, options, stderr)
+    def __init__(self, commands, options, stderr, draw_or_resign, name=None):
+        super().__init__(commands, options, stderr, draw_or_resign)
         self.go_commands = options.pop("go_commands", {}) or {}
 
         self.engine_name = self.__class__.__name__ if name is None else name


### PR DESCRIPTION
The bot can resign if the score falls very low or accept/offer draw if the score stays close to 0 for a few moves.

resign_enabled / offer_draw_enabled: Enable resigning or offering/accepting draws
resign_score: If the score is less than or equal to this value, the bot resigns (in cp)
offer_draw_score: If the absolute value of the score is less than or equal to this value, the bot offers/accepts draw (in cp) (if offer_draw_score=10, draw values will be from -10 to 10 cp)
resign_moves / offer_draw_moves: How many moves in a row the score has to be below the value, to resign or offer/accept draw
offer_draw_pieces: Maximum number of pieces the board should have offer/accept draw