### PR TITLE
Separate working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ The examples just implement `search`.
 ## Tips & Tricks
 - You can specify a different config file with the `--config` argument.
 - Here's an example systemd service definition:
-```
+```ini
 [Unit]
 Description=lichess-bot
 After=network-online.target

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Within the file `config.yml`:
 - Enter the directory containing the engine executable in the `engine: dir` field.
 - Enter the executable name in the `engine: name` field (In Windows you may need to type a name with ".exe", like "lczero.exe")
 - If you want the engine to run in a different directory (e.g., if the engine needs to read or write files at a certain location), enter that directory in the `engine: working_dir` field.
-  - If this field is blank or missing, the `lichess-bot/` directory will be used.
+  - If this field is blank or missing, the current directory will be used.
 - Leave the `weights` field empty or see [LeelaChessZero section](#leelachesszero) for Neural Nets
 
 As an optional convenience, there is a folder named `engines` within the lichess-bot folder where you can copy your engine and all the files it needs. This is the default executable location in the `config.yml.default` file.

--- a/config.yml.default
+++ b/config.yml.default
@@ -2,7 +2,7 @@ token: "xxxxxxxxxxxxxxxx"    # Lichess OAuth2 Token.
 url: "https://lichess.org/"  # Lichess base URL.
 
 engine:                      # Engine settings.
-  dir: "./engines/"          # Directory containing engines, relative to this project.
+  dir: "./engines/"          # Directory containing engines. This can be an absolute path or relative to this project if prefixed with "./".
   name: "engine_name"        # Binary name of the engine to use.
   protocol: "uci"            # "uci" or "xboard"
   ponder: true               # Think on opponent's time.
@@ -43,7 +43,7 @@ engine:                      # Engine settings.
 # engine_options:            # Any custom command line params to pass to the engine.
 #   cpuct: 3.1
   homemade_options:
-#   Hash: 256  
+#   Hash: 256
   uci_options:               # Arbitrary UCI options passed to the engine.
     Move Overhead: 100       # Increase if your bot flags games too often.
     Threads: 2               # Max CPU threads the engine can use.

--- a/config.yml.default
+++ b/config.yml.default
@@ -4,7 +4,7 @@ url: "https://lichess.org/"  # Lichess base URL.
 engine:                      # Engine settings.
   dir: "./engines/"          # Directory containing the engine. This can be an absolute path or one relative to lichess-bot/.
   name: "engine_name"        # Binary name of the engine to use.
-  working_dir: ""            # Directory where the chess engine will read and write files. If blank or missing, the lichess-bot directory is used.
+  working_dir: ""            # Directory where the chess engine will read and write files. If blank or missing, the current directory is used.
   protocol: "uci"            # "uci" or "xboard"
   ponder: true               # Think on opponent's time.
   polyglot:

--- a/conversation.py
+++ b/conversation.py
@@ -20,7 +20,7 @@ class Conversation:
 
     def command(self, line, game, cmd, board):
         if cmd == "commands" or cmd == "help":
-            self.send_reply(line, "Supported commands: !wait, !name, !howto, !eval, !queue")
+            self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval, !queue")
         elif cmd == "wait" and game.is_abortable():
             game.ping(60, 120)
             self.send_reply(line, "Waiting 60 seconds...")

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -31,7 +31,7 @@ def create_engine(config):
         raise ValueError(
             f"    Invalid engine type: {engine_type}. Expected xboard, uci, or homemade.")
     options = remove_managed_options(cfg.get(engine_type + "_options", {}) or {})
-    return Engine(commands, options, stderr)
+    return Engine(commands, options, stderr, cwd=cfg["dir"])
 
 
 def remove_managed_options(config):
@@ -61,7 +61,7 @@ MAX_CHAT_MESSAGE_LEN = 140  # maximum characters in a chat message
 
 
 class EngineWrapper:
-    def __init__(self, commands, options, stderr):
+    def __init__(self, commands, options, stderr, **kwargs):
         pass
 
     def search_for(self, board, movetime, ponder, draw_offered):
@@ -135,9 +135,9 @@ class EngineWrapper:
 
 
 class UCIEngine(EngineWrapper):
-    def __init__(self, commands, options, stderr):
+    def __init__(self, commands, options, stderr, **kwargs):
         self.go_commands = options.pop("go_commands", {}) or {}
-        self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=stderr)
+        self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=stderr, **kwargs)
         self.engine.configure(options)
         self.last_move_info = {}
 
@@ -157,9 +157,9 @@ class UCIEngine(EngineWrapper):
 
 
 class XBoardEngine(EngineWrapper):
-    def __init__(self, commands, options, stderr):
+    def __init__(self, commands, options, stderr, **kwargs):
         self.go_commands = options.pop("go_commands", {}) or {}
-        self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=stderr)
+        self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=stderr, **kwargs)
         egt_paths = options.pop("egtpath", {}) or {}
         features = self.engine.protocol.features
         egt_types_from_engine = features["egt"].split(",") if "egt" in features else []

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -65,7 +65,7 @@ MAX_CHAT_MESSAGE_LEN = 140  # maximum characters in a chat message
 
 
 class EngineWrapper:
-    def __init__(self, commands, options, stderr, draw_or_resign):
+    def __init__(self, options, draw_or_resign):
         self.scores = []
         self.draw_or_resign = draw_or_resign
         self.go_commands = options.pop("go_commands", {}) or {}
@@ -160,7 +160,7 @@ class EngineWrapper:
 
 class UCIEngine(EngineWrapper):
     def __init__(self, commands, options, stderr, draw_or_resign, **popen_args):
-        super().__init__(commands, options, stderr, draw_or_resign)
+        super().__init__(options, draw_or_resign)
         self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=stderr, **popen_args)
         self.engine.configure(options)
 
@@ -181,7 +181,7 @@ class UCIEngine(EngineWrapper):
 
 class XBoardEngine(EngineWrapper):
     def __init__(self, commands, options, stderr, draw_or_resign, **popen_args):
-        super().__init__(commands, options, stderr, draw_or_resign)
+        super().__init__(options, draw_or_resign)
         self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=stderr, **popen_args)
         egt_paths = options.pop("egtpath", {}) or {}
         features = self.engine.protocol.features

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -11,9 +11,7 @@ logger = logging.getLogger(__name__)
 @backoff.on_exception(backoff.expo, BaseException, max_time=120)
 def create_engine(config):
     cfg = config["engine"]
-    engine_dir = cfg["dir"]
-    engine_executable = cfg["name"]
-    engine_path = os.path.join(engine_dir, engine_executable)
+    engine_path = os.path.join(cfg["dir"], cfg["name"])
     engine_working_dir = cfg.get("working_dir") or os.getcwd()
     engine_type = cfg.get("protocol")
     engine_options = cfg.get("engine_options")

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -156,9 +156,9 @@ class EngineWrapper:
 
 
 class UCIEngine(EngineWrapper):
-    def __init__(self, commands, options, stderr, draw_or_resign, **kwargs):
+    def __init__(self, commands, options, stderr, draw_or_resign, **popen_args):
         super().__init__(commands, options, stderr, draw_or_resign)
-        self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=stderr, **kwargs)
+        self.engine = chess.engine.SimpleEngine.popen_uci(commands, stderr=stderr, **popen_args)
         self.engine.configure(options)
 
     def stop(self):
@@ -177,9 +177,9 @@ class UCIEngine(EngineWrapper):
 
 
 class XBoardEngine(EngineWrapper):
-    def __init__(self, commands, options, stderr, draw_or_resign, **kwargs):
+    def __init__(self, commands, options, stderr, draw_or_resign, **popen_args):
         super().__init__(commands, options, stderr, draw_or_resign)
-        self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=stderr, **kwargs)
+        self.engine = chess.engine.SimpleEngine.popen_xboard(commands, stderr=stderr, **popen_args)
         egt_paths = options.pop("egtpath", {}) or {}
         features = self.engine.protocol.features
         egt_types_from_engine = features["egt"].split(",") if "egt" in features else []


### PR DESCRIPTION
This PR lets the user specify which directory the bot should run from. This is useful where the bot needs to read files or writes files and the user does not want them in the lichess directory.

If the new working directory configuration is blank or missing, the current working directory is used, which I believe is the current behavior. This change should be backward compatible with older config files.

This implements the request in issue #232.