### PR TITLE
Offer draw or resign based on online egtb score

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Besides the above, there are many possible options within `config.yml` for confi
     - `resign_moves`: The evaluation has to be less than or equal to `resign_score` for `resign_moves` amount of moves for the bot to resign.
     - `offer_draw_enabled`: Whether the bot is allowed to offer/accept draw based on the evaluation.
     - `offer_draw_score`: The absolute value of the engine evaluation has to be less than or equal to `offer_draw_score` for the bot to offer/accept draw.
-    - `offer_draw_egtb_score`: The absolute value of the wdl score from the online egtb has to be less than or equal to `offer_draw_score` for the bot to offer/accept draw.
-    - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_egtb_score` amount of moves for the bot to offer/accept draw.
+    - `offer_draw_egtb_score`: The absolute value of the wdl score from the online egtb has to be less than or equal to `offer_draw_egtb_score` for the bot to offer/accept draw.
+    - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 - `online_moves`: This section gives your bot access to various online resources for choosing moves like opening books and endgame tablebases. This can be a supplement or a replacement for chess databases stored on your computer. There are three sections that correspond to three different online databases:
     1. `chessdb_book`: Consults a [Chinese chess position database](https://www.chessdb.cn/), which also hosts a xiangqi database.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Besides the above, there are many possible options within `config.yml` for confi
     - `resign_moves`: The evaluation has to be less than or equal to `resign_score` for `resign_moves` amount of moves for the bot to resign.
     - `offer_draw_enabled`: Whether the bot is allowed to offer/accept draw based on the evaluation.
     - `offer_draw_score`: The absolute value of the engine evaluation has to be less than or equal to `offer_draw_score` for the bot to offer/accept draw.
-    - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
+    - `offer_draw_egtb_score`: The absolute value of the wdl score from the online egtb has to be less than or equal to `offer_draw_score` for the bot to offer/accept draw.
+    - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_egtb_score` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 - `online_moves`: This section gives your bot access to various online resources for choosing moves like opening books and endgame tablebases. This can be a supplement or a replacement for chess databases stored on your computer. There are three sections that correspond to three different online databases:
     1. `chessdb_book`: Consults a [Chinese chess position database](https://www.chessdb.cn/), which also hosts a xiangqi database.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Besides the above, there are many possible options within `config.yml` for confi
     - `resign_moves`: The evaluation has to be less than or equal to `resign_score` for `resign_moves` amount of moves for the bot to resign.
     - `offer_draw_enabled`: Whether the bot is allowed to offer/accept draw based on the evaluation.
     - `offer_draw_score`: The absolute value of the engine evaluation has to be less than or equal to `offer_draw_score` for the bot to offer/accept draw.
-    - `offer_draw_egtb_score`: The absolute value of the wdl score from the online egtb has to be less than or equal to `offer_draw_egtb_score` for the bot to offer/accept draw.
+    - `offer_draw_egtb_count_wdl_1_as_draw`: If true the bot will offer/accept draw also in positions with wdl of 1 or -1.
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 - `online_moves`: This section gives your bot access to various online resources for choosing moves like opening books and endgame tablebases. This can be a supplement or a replacement for chess databases stored on your computer. There are three sections that correspond to three different online databases:

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Besides the above, there are many possible options within `config.yml` for confi
 - `draw_or_resign`: This section allows your bot to resign or offer/accept draw based on the evaluation by the engine. XBoard engines can resign and offer/accept draw without this feature enabled.
     - `resign_enabled`: Whether the bot is allowed to resign based on the evaluation.
     - `resign_score`: The engine evaluation has to be less than or equal to `resign_score` for the bot to resign.
+    - `resign_for_egtb_minus_two`: If true the bot will resign in positions where the online_egtb returns a wdl of -2.
     - `resign_moves`: The evaluation has to be less than or equal to `resign_score` for `resign_moves` amount of moves for the bot to resign.
     - `offer_draw_enabled`: Whether the bot is allowed to offer/accept draw based on the evaluation.
     - `offer_draw_score`: The absolute value of the engine evaluation has to be less than or equal to `offer_draw_score` for the bot to offer/accept draw.
-    - `offer_draw_egtb_count_wdl_1_as_draw`: If true the bot will offer/accept draw also in positions with wdl of 1 or -1.
+    - `offer_draw_for_egtb_zero`: If true the bot will offer/accept draw in positions where the online_egtb returns a wdl of 0.
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 - `online_moves`: This section gives your bot access to various online resources for choosing moves like opening books and endgame tablebases. This can be a supplement or a replacement for chess databases stored on your computer. There are three sections that correspond to three different online databases:

--- a/config.yml.default
+++ b/config.yml.default
@@ -26,7 +26,7 @@ engine:                      # Engine settings.
     resign_moves: 3          # How many moves in a row the score has to be below the resign value
     offer_draw_enabled: false
     offer_draw_score: 0      # If the absolute value of the score is less than or equal to this value, the bot offers/accepts draw (in cp)
-    offer_draw_egtb_score: 0 # If the absolute value of the wdl score is less than or equal to this value, the bot offers/accepts draw
+    offer_draw_egtb_count_wdl_1_as_draw: false # If true positions with wdl of 1 or -1 will also count as draws.
     offer_draw_moves: 5      # How many moves in a row the absolute value of the score has to be below the draw value
     offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw
   online_moves:

--- a/config.yml.default
+++ b/config.yml.default
@@ -26,6 +26,7 @@ engine:                      # Engine settings.
     resign_moves: 3          # How many moves in a row the score has to be below the resign value
     offer_draw_enabled: false
     offer_draw_score: 0      # If the absolute value of the score is less than or equal to this value, the bot offers/accepts draw (in cp)
+    offer_draw_egtb_score: 0 # If the absolute value of the wdl score is less than or equal to this value, the bot offers/accepts draw
     offer_draw_moves: 5      # How many moves in a row the absolute value of the score has to be below the draw value
     offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw
   online_moves:

--- a/config.yml.default
+++ b/config.yml.default
@@ -22,24 +22,25 @@ engine:                      # Engine settings.
     max_depth: 8             # Half move max depth.
   draw_or_resign:
     resign_enabled: false
-    resign_score: -1000      # If the score is less than or equal to this value, the bot resigns (in cp)
-    resign_moves: 3          # How many moves in a row the score has to be below the resign value
+    resign_score: -1000      # If the score is less than or equal to this value, the bot resigns (in cp).
+    resign_for_egtb_minus_two: true # If true the bot will resign in positions where the online_egtb returns a wdl of -2.
+    resign_moves: 3          # How many moves in a row the score has to be below the resign value.
     offer_draw_enabled: false
-    offer_draw_score: 0      # If the absolute value of the score is less than or equal to this value, the bot offers/accepts draw (in cp)
-    offer_draw_egtb_count_wdl_1_as_draw: false # If true positions with wdl of 1 or -1 will also count as draws.
-    offer_draw_moves: 5      # How many moves in a row the absolute value of the score has to be below the draw value
-    offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw
+    offer_draw_score: 0      # If the absolute value of the score is less than or equal to this value, the bot offers/accepts draw (in cp).
+    offer_draw_for_egtb_zero: true # If true the bot will offer/accept draw in positions where the online_egtb returns a wdl of 0.
+    offer_draw_moves: 5      # How many moves in a row the absolute value of the score has to be below the draw value.
+    offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw.
   online_moves:
     chessdb_book:
       enabled: false
       min_time: 20
-      move_quality: "good"   # One of "all", "good", "best"
-      min_depth: 20          # Only for move_quality: "best"
+      move_quality: "good"   # One of "all", "good", "best".
+      min_depth: 20          # Only for move_quality: "best".
       contribute: true
     lichess_cloud_analysis:
       enabled: false
       min_time: 20
-      move_quality: "good"   # One of "good", "best"
+      move_quality: "good"   # One of "good", "best".
       max_score_difference: 50 # Only for move_quality: "good". The maximum score difference (in cp) between the best move and the other moves.
       min_depth: 20
       min_knodes: 0
@@ -47,8 +48,8 @@ engine:                      # Engine settings.
       enabled: false
       min_time: 20
       max_pieces: 7
-      source: "lichess"      # One of "lichess", "chessdb"
-      move_quality: "best"   # One of "good", "best"
+      source: "lichess"      # One of "lichess", "chessdb".
+      move_quality: "best"   # One of "good", "best".
 # engine_options:            # Any custom command line params to pass to the engine.
 #   cpuct: 3.1
   homemade_options:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -92,7 +92,7 @@ class EngineWrapper:
     def offer_draw_or_resign(self, result, board):
         if self.draw_or_resign.get('offer_draw_enabled', False) and len(self.scores) >= self.draw_or_resign.get('offer_draw_moves', 5):
             scores = self.scores[-self.draw_or_resign.get('offer_draw_moves', 5):]
-            pieces_on_board = len([board.piece_type_at(sq) for sq in chess.SQUARES if board.piece_type_at(sq)])
+            pieces_on_board = chess.popcount(board.occupied)
             scores_near_draw = lambda score: abs(score.relative.score(mate_score=40000)) <= self.draw_or_resign.get('offer_draw_score', 0)
             if len(scores) == len(list(filter(scores_near_draw, scores))) and pieces_on_board <= self.draw_or_resign.get('offer_draw_pieces', 10):
                 result.draw_offered = True

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -550,7 +550,7 @@ def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
     if best_move is None:
         best_move = get_chessdb_move(li, board, game, chessdb_cfg)
     else:
-        if draw_or_resign_cfg.get('offer_draw_enabled', False) and abs(wdl) <= draw_or_resign_cfg.get('offer_draw_egtb_score', 0):
+        if draw_or_resign_cfg.get('offer_draw_enabled', False) and abs(wdl) <= draw_or_resign_cfg.get('offer_draw_egtb_count_wdl_1_as_draw', False):
             offer_draw = True
         if draw_or_resign_cfg.get('resign_enabled', False) and wdl == -2:
             resign = True

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -550,9 +550,9 @@ def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
     if best_move is None:
         best_move = get_chessdb_move(li, board, game, chessdb_cfg)
     else:
-        if draw_or_resign_cfg.get('offer_draw_enabled', False) and abs(wdl) <= draw_or_resign_cfg.get('offer_draw_egtb_count_wdl_1_as_draw', False):
+        if draw_or_resign_cfg.get('offer_draw_enabled', False) and draw_or_resign_cfg.get('offer_draw_for_egtb_zero', True) and wdl == 0:
             offer_draw = True
-        if draw_or_resign_cfg.get('resign_enabled', False) and wdl == -2:
+        if draw_or_resign_cfg.get('resign_enabled', False) and draw_or_resign_cfg.get('resign_for_egtb_minus_two', True) and wdl == -2:
             resign = True
 
     if best_move is None:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -554,8 +554,10 @@ def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
             offer_draw = True
         if draw_or_resign_cfg.get('resign_enabled', False) and wdl == -2:
             resign = True
+
     if best_move is None:
         best_move = get_lichess_cloud_move(li, board, game, lichess_cloud_cfg)
+
     if best_move:
         return chess.engine.PlayResult(chess.Move.from_uci(best_move), None, draw_offered=offer_draw, resigned=resign)
     return chess.engine.PlayResult(None, None)


### PR DESCRIPTION
`resign_moves`, `offer_draw_moves` and `offer_draw_pieces` are not taken into account when offering/accepting draw or resigning based on the online egtb score.
In lichess-bot.py line 293 I added `and len(board.move_stack) >= 2` because if the bot resigns on the first move, the game is instead aborted.
closes #421