### PR TITLE
Fix !wait command bug

### DIFF
--- a/conversation.py
+++ b/conversation.py
@@ -22,7 +22,7 @@ class Conversation:
         if cmd == "commands" or cmd == "help":
             self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval, !queue")
         elif cmd == "wait" and game.is_abortable():
-            game.ping(60, 120)
+            game.ping(60, 120, 120)
             self.send_reply(line, "Waiting 60 seconds...")
         elif cmd == "name":
             name = game.me.name


### PR DESCRIPTION
If someone uses `!wait` on the first move the bot would raise `Backing off play_game(...) for 1s (TypeError: ping() missing 1 required positional argument: 'disconnect_in')` because we didn't set the `disconnect_in` parameter.