### PR TITLE
Check that correspondence_queue is empty not False

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -193,7 +193,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename)
                     game_id = correspondence_queue.get()
                     # stop checking in on games if we have checked in on all games since the last correspondence_ping
                     if not game_id:
-                        if is_correspondence_ping and correspondence_queue:
+                        if is_correspondence_ping and not correspondence_queue.empty():
                             correspondence_queue.put("")
                         else:
                             wait_for_correspondence_ping = True


### PR DESCRIPTION
Since Python Queues are meant for multithreaded contexts, it does not
act like other Python collections. In this case, an empty queue is not
considered False. So, the loop on line 192 never exits because the
condition on line 196 is always true after a corresondence ping. This
change makes the check for empty explicit.

This should close #427.