### PR TITLE
Fix cloud eval for variants

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -465,7 +465,7 @@ def get_lichess_cloud_move(li, board, game, lichess_cloud_cfg):
     variant = "standard" if board.uci_variant == "chess" else board.uci_variant
 
     try:
-        data = li.api_get(f"https://lichess.org/api/cloud-eval?fen={board.fen()}&multiPv={multipv}&variant={variant}", raise_for_status=False)
+        data = li.api_get(f"https://lichess.org/api/cloud-eval?fen={board.fen()}&multiPv={multipv}&variant=\"{variant}\"", raise_for_status=False)
         if "error" not in data:
             if quality == "best":
                 depth = data["depth"]


### PR DESCRIPTION
Currently for variants `https://lichess.org/api/cloud-eval?fen=rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0&multiPv=5&variant=threeCheck` is sent which gives the result `{"error":"Not found"}`
This is fixed by adding quotes on the variant name.
`https://lichess.org/api/cloud-eval?fen=rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0&multiPv=5&variant="threeCheck"`

Copy and paste the links in your browser to check.