### PR TITLE
Record games played by bot to local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     hello: Hi, {opponent}! I'm {me}. Good luck!
     goodbye: Good game!
 ```
+  - `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. Each game will be written to a uniquely named file.
+```yml
+  pgn_directory: "game_records"
+```
 
 ## Lichess Upgrade to Bot Account
 **WARNING: This is irreversible. [Read more about upgrading to bot account](https://lichess.org/api#operation/botAccountUpgrade).**

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     hello: Hi, {opponent}! I'm {me}. Good luck!
     goodbye: Good game!
 ```
-  - `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. Each game will be written to a uniquely named file.
+  - `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score (a positive score indicates white's advantage) and principal variation. Each game will be written to a uniquely named file.
 ```yml
   pgn_directory: "game_records"
 ```

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     hello: Hi, {opponent}! I'm {me}. Good luck!
     goodbye: Good game!
 ```
-  - `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score (a positive score indicates white's advantage) and principal variation. Each game will be written to a uniquely named file.
+  - `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. The score is written with a tag of the form `[%eval s,d]`, where `s` is the score in pawns (positive means white has the advantage), and `d` is the depth of the search. Each game will be written to a uniquely named file.
 ```yml
   pgn_directory: "game_records"
 ```

--- a/config.yml.default
+++ b/config.yml.default
@@ -125,4 +125,4 @@ greeting:
     hello: "Hi! I'm {me}. Good luck! Type !help for a list of commands I can respond to." # Message to send to chat at the start of a game
     goodbye: "Good game!" # Message to send to chat at the end of a game
 
-# pgn_directory: 'game_records' # A directory where PGN-format records of the bot's games are kept
+# pgn_directory: "game_records" # A directory where PGN-format records of the bot's games are kept

--- a/config.yml.default
+++ b/config.yml.default
@@ -124,3 +124,5 @@ greeting:
     # Any other words in curly braces will be removed.
     hello: "Hi! I'm {me}. Good luck! Type !help for a list of commands I can respond to." # Message to send to chat at the start of a game
     goodbye: "Good game!" # Message to send to chat at the end of a game
+
+# pgn_directory: 'game_records' # A directory where PGN-format records of the bot's games are kept

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -110,6 +110,8 @@ class EngineWrapper:
         result = self.engine.play(board, time_limit, info=chess.engine.INFO_ALL, ponder=ponder, draw_offered=draw_offered)
         self.last_move_info = result.info.copy()
         self.move_commentary.append(self.last_move_info.copy())
+        if not self.move_commentary[-1].get("pv"):
+            self.move_commentary[-1]["pv"] = [result.move]
         self.scores.append(self.last_move_info.get("score", chess.engine.PovScore(chess.engine.Mate(1), board.turn)))
         result = self.offer_draw_or_resign(result, board)
         self.last_move_info["ponderpv"] = board.variation_san(self.last_move_info.get("pv", []))

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -49,6 +49,7 @@ class Termination(str, Enum):
     RESIGN = "resign"
     ABORT = "aborted"
     DRAW = "draw"
+    IN_PROGRESS = "started"
 
 
 class GameEnding(str, Enum):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -133,8 +133,6 @@ class EngineWrapper:
         result = self.engine.play(board, time_limit, info=chess.engine.INFO_ALL, ponder=ponder, draw_offered=draw_offered)
         self.last_move_info = result.info.copy()
         self.move_commentary.append(self.last_move_info.copy())
-        if not self.move_commentary[-1].get("pv"):
-            self.move_commentary[-1]["pv"] = [result.move]
         self.scores.append(self.last_move_info.get("score", chess.engine.PovScore(chess.engine.Mate(1), board.turn)))
         result = self.offer_draw_or_resign(result, board)
         self.last_move_info["ponderpv"] = board.variation_san(self.last_move_info.get("pv", []))

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -68,6 +68,7 @@ class EngineWrapper:
         self.draw_or_resign = draw_or_resign
         self.go_commands = options.pop("go_commands", {}) or {}
         self.last_move_info = {}
+        self.move_commentary = []
 
     def search_for(self, board, movetime, ponder, draw_offered):
         return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder, draw_offered)
@@ -108,6 +109,7 @@ class EngineWrapper:
     def search(self, board, time_limit, ponder, draw_offered):
         result = self.engine.play(board, time_limit, info=chess.engine.INFO_ALL, ponder=ponder, draw_offered=draw_offered)
         self.last_move_info = result.info.copy()
+        self.move_commentary.append(self.last_move_info.copy())
         self.scores.append(self.last_move_info.get("score", chess.engine.PovScore(chess.engine.Mate(1), board.turn)))
         result = self.offer_draw_or_resign(result, board)
         self.last_move_info["ponderpv"] = board.variation_san(self.last_move_info.get("pv", []))

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -58,6 +58,29 @@ class GameEnding(str, Enum):
     INCOMPLETE = "*"
 
 
+def translate_termination(termination, board, winner_name, winner_color):
+    if termination == Termination.MATE:
+        return f"{winner_name} mates"
+    elif termination == Termination.TIMEOUT:
+        return "Time forfeiture"
+    elif termination == Termination.RESIGN:
+        resigner = "black" if winner_color == "white" else "white"
+        return f"{resigner.title()} resigns"
+    elif termination == Termination.ABORT:
+        return "Game aborted"
+    elif termination == Termination.DRAW:
+        if board.is_fifty_moves():
+            return "50-move rule"
+        elif board.is_repetition():
+            return "Threefold repetition"
+        else:
+            return "Draw by agreement"
+    elif termination:
+        return termination
+    else:
+        return ""
+
+
 PONDERPV_CHARACTERS = 12  # the length of ", ponderpv: "
 MAX_CHAT_MESSAGE_LEN = 140  # maximum characters in a chat message
 
@@ -204,27 +227,10 @@ class XBoardEngine(EngineWrapper):
         else:
             game_result = GameEnding.INCOMPLETE
 
-        if termination == Termination.MATE:
-            endgame_message = f"{winner.title()} mates"
-        elif termination == Termination.TIMEOUT:
-            endgame_message = "Time forfeiture"
-        elif termination == Termination.RESIGN:
-            resigner = "black" if winner == "white" else "white"
-            endgame_message = f"{resigner.title()} resigns"
-        elif termination == Termination.ABORT:
-            endgame_message = "Game aborted"
-        elif termination == Termination.DRAW:
-            if board.is_fifty_moves():
-                endgame_message = "50-move rule"
-            elif board.is_repetition():
-                endgame_message = "Threefold repetition"
-            else:
-                endgame_message = "Draw by agreement"
-        elif termination:
-            endgame_message = termination
-        else:
-            endgame_message = ""
-
+        endgame_message = translate_termination(termination,
+                                                board,
+                                                game.white if winner == "white" else game.black,
+                                                winner)
         if endgame_message:
             endgame_message = " {" + endgame_message + "}"
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -730,11 +730,14 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
     game_record.headers["Result"] = result
 
     index_of_first_board_move_with_commentary = 0
-    commentary_moves = [comment["pv"][0] for comment in engine.move_commentary]
+    commentary_moves = [comment["pv"][0] for comment in engine.move_commentary][:-1]
     while True:
         commented_board_moves = board.move_stack[index_of_first_board_move_with_commentary::2]
         if commented_board_moves == commentary_moves:
             break
+        elif index_of_first_board_move_with_commentary >= len(board.move_stack):
+            logger.warning("Could not write game record.")
+            return
         else:
             index_of_first_board_move_with_commentary += 1
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -697,14 +697,10 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
 
     # If the bot got disconnected in the middle of the game, read the previously
     # written game record to preserve bot's commentary from last play.
-    game_record = None
-    try:
+    if os.path.isfile(game_path):
         with open(game_path) as game_data:
             game_record = chess.pgn.read_game(game_data)
-    except FileNotFoundError:
-        pass
-
-    if not game_record:
+    else:
         game_record = chess.pgn.Game()
         game_record.headers["Event"] = f"Lichess {game.perf_name} Game"
         game_record.headers["Site"] = game.url()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -724,7 +724,7 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
     game_record.headers["Result"] = result
 
     index_of_first_board_move_with_commentary = 0
-    commentary_moves = [c["pv"][0] for c in engine.move_commentary]
+    commentary_moves = [comment["pv"][0] for comment in engine.move_commentary]
     while True:
         commented_board_moves = board.move_stack[index_of_first_board_move_with_commentary::2]
         if commented_board_moves == commentary_moves:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -700,6 +700,7 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
     if os.path.isfile(game_path):
         with open(game_path) as game_data:
             game_record = chess.pgn.read_game(game_data)
+        game_record.headers.pop("Termination", "")
     else:
         game_record = chess.pgn.Game()
         game_record.headers["Event"] = f"Lichess {game.perf_name} Game"
@@ -737,7 +738,7 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
                                                             board,
                                                             game.white if winner == "white" else game.black,
                                                             winner)
-    if "mates" not in terminate_message:
+    if "mates" not in terminate_message and termination != engine_wrapper.Termination.IN_PROGRESS:
         game_record.headers["Termination"] = terminate_message
 
     # Match the engine commentary with the moves on the board

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -780,7 +780,12 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
 
         if index % 2 != 0:
             continue
-        commentary = engine.move_commentary[index // 2]
+
+        try:
+            commentary = engine.move_commentary[index // 2]
+        except IndexError:
+            continue
+
         score = commentary.get("score")
         if score is not None:
             pov_score = score.pov(chess.WHITE if game.is_white else chess.BLACK)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -744,15 +744,16 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         game_record.headers["Termination"] = terminate_message
 
     # Match the engine commentary with the moves on the board
-    commentary_moves = [comment["pv"][0] for comment in engine.move_commentary]
-    for index in range(len(board.move_stack)):
-        player_moves = board.move_stack[index::2]
-        if all(played == commented for played, commented in zip(player_moves, commentary_moves)):
-            index_of_first_board_move_with_commentary = index
-            break
-    else:
-        logger.warning("Could not write game record.")
-        return
+    index_of_first_board_move_with_commentary = len(board.move_stack)
+    try:
+        commentary_moves = [comment["pv"][0] for comment in engine.move_commentary]
+        for index in range(len(board.move_stack)):
+            player_moves = board.move_stack[index::2]
+            if all(played == commented for played, commented in zip(player_moves, commentary_moves)):
+                index_of_first_board_move_with_commentary = index
+                break
+    except Exception:
+        pass
 
     # Move game record position to last move in file
     current_node = game_record.game()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -350,8 +350,8 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
     try:
         print_pgn_game_record(config, game, board, engine, start_datetime)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(repr(e))
 
     if is_correspondence and not is_game_over(game):
         logger.info(f"--- Disconnecting from {game.url()}")

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -345,9 +345,13 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
         except StopIteration:
             break
 
-    print_pgn_game_record(config, game, board, engine, start_datetime)
     engine.stop()
     engine.quit()
+
+    try:
+        print_pgn_game_record(config, game, board, engine, start_datetime)
+    except Exception:
+        pass
 
     if is_correspondence and not is_game_over(game):
         logger.info(f"--- Disconnecting from {game.url()}")

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -735,9 +735,9 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
     game_record.headers["Result"] = result
 
     terminate_message = engine_wrapper.translate_termination(termination,
-                                                            board,
-                                                            game.white if winner == "white" else game.black,
-                                                            winner)
+                                                             board,
+                                                             game.white if winner == "white" else game.black,
+                                                             winner)
     if "mates" not in terminate_message and termination != engine_wrapper.Termination.IN_PROGRESS:
         game_record.headers["Termination"] = terminate_message
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -733,17 +733,15 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         result = ending.INCOMPLETE
     game_record.headers["Result"] = result
 
-    index_of_first_board_move_with_commentary = 0
-    commentary_moves = [comment["pv"][0] for comment in engine.move_commentary][:-1]
-    while True:
-        commented_board_moves = board.move_stack[index_of_first_board_move_with_commentary::2]
-        if commented_board_moves == commentary_moves:
+    commentary_moves = [comment["pv"][0] for comment in engine.move_commentary]
+    for index in range(len(board.move_stack)):
+        player_moves = board.move_stack[index::2]
+        if all(played == commented for played, commented in zip(player_moves, commentary_moves)):
+            index_of_first_board_move_with_commentary = index
             break
-        elif index_of_first_board_move_with_commentary >= len(board.move_stack):
-            logger.warning("Could not write game record.")
-            return
-        else:
-            index_of_first_board_move_with_commentary += 1
+    else:
+        logger.warning("Could not write game record.")
+        return
 
     current_node = game_record.game()
     moves_from_file = 0

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -777,6 +777,7 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
     # Write new commented moves to game_record.
     for index, move in enumerate(board.move_stack[index_of_first_board_move_with_commentary:]):
         current_node = current_node.add_main_variation(move)
+
         if index % 2 != 0:
             continue
         commentary = engine.move_commentary[index // 2]

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -747,10 +747,17 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
     # Match the engine commentary with the moves on the board
     index_of_first_board_move_with_commentary = len(board.move_stack)
     try:
-        commentary_moves = [comment["pv"][0] for comment in engine.move_commentary]
+        commentary_moves = []
+        for comment in engine.move_commentary:
+            if "pv" in comment:
+                commentary_moves.append(comment["pv"][0])
+            elif "currmove" in comment:
+                commentary_moves.append(comment["currmove"])
+            else:
+                commentary_moves.append(None)
         for index in range(len(board.move_stack)):
             player_moves = board.move_stack[index::2]
-            if all(played == commented for played, commented in zip(player_moves, commentary_moves)):
+            if all(played == commented or commented is None for played, commented in zip(player_moves, commentary_moves)):
                 index_of_first_board_move_with_commentary = index
                 break
     except Exception:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -733,6 +733,13 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         result = ending.INCOMPLETE
     game_record.headers["Result"] = result
 
+    terminate_message = engine_wrapper.translate_termination(termination,
+                                                            board,
+                                                            game.white if winner == "white" else game.black,
+                                                            winner)
+    if "mates" not in terminate_message:
+        game_record.headers["Termination"] = terminate_message
+
     commentary_moves = [comment["pv"][0] for comment in engine.move_commentary]
     for index in range(len(board.move_stack)):
         player_moves = board.move_stack[index::2]

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -692,6 +692,7 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         pass
 
     game_file_name = f"{game.white} vs {game.black} - {game.id}.pgn"
+    game_file_name = "".join(c for c in game_file_name if c != "?")
     game_path = os.path.join(game_directory, game_file_name)
 
     # If the bot got disconnected in the middle of the game, read the previously

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -705,7 +705,13 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         game_record.headers["Round"] = "1"
         game_record.headers["White"] = game.white
         game_record.headers["Black"] = game.black
-        game_record.headers["TimeControl"] = f"{game.clock_initial // 1000}+{game.clock_increment // 1000}"
+        game_time_seconds = game.clock_initial // 1000
+        game_time_min = str(game_time_seconds // 60)
+        seconds = game_time_seconds % 60
+        game_time_sec = f":{seconds}" if seconds else ""
+        game_time_inc = f"+{game.clock_increment // 1000}" if game.clock_increment else ""
+        time_control = game_time_min + game_time_sec + game_time_inc
+        game_record.headers["TimeControl"] = time_control
         if game.variant_name != "Standard":
             game_record.headers["Variant"] = game.variant_name
         if game.initial_fen != "startpos":

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -756,10 +756,6 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         current_node = current_node.next()
         moves_from_file += 1
 
-    while moves_from_file + len(engine.move_commentary) > len(board.move_stack):
-        current_node = current_node.parent
-        moves_from_file -= 1
-
     for move in board.move_stack[moves_from_file:index_of_first_board_move_with_commentary]:
         current_node = current_node.add_main_variation(move)
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -692,7 +692,7 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         pass
 
     game_file_name = f"{game.white} vs {game.black} - {game.id}.pgn"
-    game_file_name = "".join(c for c in game_file_name if c != "?")
+    game_file_name = "".join(c for c in game_file_name if c not in '<>:"/\|?*')
     game_path = os.path.join(game_directory, game_file_name)
 
     # If the bot got disconnected in the middle of the game, read the previously

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -682,7 +682,7 @@ def tell_user_game_result(game, board):
 
 
 def print_pgn_game_record(config, game, board, engine, start_datetime):
-    game_directory = config.get('pgn_directory')
+    game_directory = config.get("pgn_directory")
     if not game_directory:
         return
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -351,7 +351,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     try:
         print_pgn_game_record(config, game, board, engine, start_datetime)
     except Exception as e:
-        logger.warning(repr(e))
+        logger.warning(f"Error writing game record: {repr(e)}")
 
     if is_correspondence and not is_game_over(game):
         logger.info(f"--- Disconnecting from {game.url()}")

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -786,14 +786,8 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         except IndexError:
             continue
 
-        score = commentary.get("score")
-        if score is not None:
-            pov_score = score.pov(chess.WHITE if game.is_white else chess.BLACK)
-            numeric_score = pov_score.score()
-            comment = f"score: {numeric_score if numeric_score is not None else pov_score}"
-        else:
-            comment = ""
-        current_node.parent.add_line(commentary.get("pv", []), comment=comment)
+        pv_node = current_node.parent.add_line(commentary.get("pv", []))
+        pv_node.set_eval(commentary.get("score"), commentary.get("depth"))
 
     # Write game_record to file.
     with open(game_path, "w") as game_record_destination:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -706,6 +706,8 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         game_record.headers["White"] = game.white
         game_record.headers["Black"] = game.black
         game_record.headers["TimeControl"] = f"{game.clock_initial // 1000}+{game.clock_increment // 1000}"
+        if game.variant_name != "Standard":
+            game_record.headers["Variant"] = game.variant_name
         if game.initial_fen != "startpos":
             game_record.headers["Setup"] = "1"
             game_record.headers["FEN"] = game.initial_fen

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -692,7 +692,7 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
         pass
 
     game_file_name = f"{game.white} vs {game.black} - {game.id}.pgn"
-    game_file_name = "".join(c for c in game_file_name if c not in '<>:"/\|?*')
+    game_file_name = "".join(c for c in game_file_name if c not in '<>:"/\\|?*')
     game_path = os.path.join(game_directory, game_file_name)
 
     # If the bot got disconnected in the middle of the game, read the previously

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -195,7 +195,7 @@ def test_sf():
     CONFIG["engine"]["dir"] = "./TEMP/"
     CONFIG["engine"]["name"] = f"sf{file_extension}"
     CONFIG["engine"]["uci_options"]["Threads"] = 1
-    CONFIG['pgn_directory'] = "TEMP/sf_game_record"
+    CONFIG["pgn_directory"] = "TEMP/sf_game_record"
     stockfish_path = f"./TEMP/sf2{file_extension}"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")
@@ -220,7 +220,7 @@ def test_lc0():
     CONFIG["engine"]["uci_options"]["Threads"] = 1
     CONFIG["engine"]["uci_options"].pop("Hash", None)
     CONFIG["engine"]["uci_options"].pop("Move Overhead", None)
-    CONFIG['pgn_directory'] = "TEMP/lc0_game_record"
+    CONFIG["pgn_directory"] = "TEMP/lc0_game_record"
     stockfish_path = "./TEMP/sf2.exe"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")
@@ -244,7 +244,7 @@ def test_sjeng():
     CONFIG["engine"]["protocol"] = "xboard"
     CONFIG["engine"]["name"] = "sjeng.exe"
     CONFIG["engine"]["ponder"] = False
-    CONFIG['pgn_directory'] = "TEMP/sjeng_game_record"
+    CONFIG["pgn_directory"] = "TEMP/sjeng_game_record"
     stockfish_path = "./TEMP/sf2.exe"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")
@@ -272,7 +272,7 @@ def test_homemade():
     CONFIG["token"] = ""
     CONFIG["engine"]["name"] = "Stockfish"
     CONFIG["engine"]["protocol"] = "homemade"
-    CONFIG['pgn_directory'] = "TEMP/homemade_game_record"
+    CONFIG["pgn_directory"] = "TEMP/homemade_game_record"
     stockfish_path = f"./TEMP/sf2{file_extension}"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -201,6 +201,7 @@ def test_sf():
     shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing SF")
     assert win == "1"
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))
 
 
 @pytest.mark.timeout(150, method="thread")
@@ -226,6 +227,7 @@ def test_lc0():
     shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing LC0")
     assert win == "1"
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))
 
 
 @pytest.mark.timeout(150, method="thread")
@@ -250,6 +252,7 @@ def test_sjeng():
     shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing Sjeng")
     assert win == "1"
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))
 
 
 @pytest.mark.timeout(150, method="thread")
@@ -280,3 +283,4 @@ def test_homemade():
         file.write(original_strategies)
     lichess_bot.logger.info("Finished Testing Homemade")
     assert win == "1"
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -195,6 +195,7 @@ def test_sf():
     CONFIG["engine"]["dir"] = "./TEMP/"
     CONFIG["engine"]["name"] = f"sf{file_extension}"
     CONFIG["engine"]["uci_options"]["Threads"] = 1
+    CONFIG['pgn_directory'] = "TEMP/sf_game_record"
     stockfish_path = f"./TEMP/sf2{file_extension}"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")
@@ -219,6 +220,7 @@ def test_lc0():
     CONFIG["engine"]["uci_options"]["Threads"] = 1
     CONFIG["engine"]["uci_options"].pop("Hash", None)
     CONFIG["engine"]["uci_options"].pop("Move Overhead", None)
+    CONFIG['pgn_directory'] = "TEMP/lc0_game_record"
     stockfish_path = "./TEMP/sf2.exe"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")
@@ -242,6 +244,7 @@ def test_sjeng():
     CONFIG["engine"]["protocol"] = "xboard"
     CONFIG["engine"]["name"] = "sjeng.exe"
     CONFIG["engine"]["ponder"] = False
+    CONFIG['pgn_directory'] = "TEMP/sjeng_game_record"
     stockfish_path = "./TEMP/sf2.exe"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")
@@ -269,6 +272,7 @@ def test_homemade():
     CONFIG["token"] = ""
     CONFIG["engine"]["name"] = "Stockfish"
     CONFIG["engine"]["protocol"] = "homemade"
+    CONFIG['pgn_directory'] = "TEMP/homemade_game_record"
     stockfish_path = f"./TEMP/sf2{file_extension}"
     win = run_bot(CONFIG, logging_level, stockfish_path)
     shutil.rmtree("logs")


### PR DESCRIPTION
Add a configuration to have lichess-bot record a bot's games to a folder on the user's computer. The games are written in PGN format and include the bot's evaluation of the move--including the score and principle variation.

Depending on what characters are allowed in lichess account names, some more characters may need to be filtered out of file names. Right now, only question marks are removed (as from uncertain chess ratings).

Also, this may be too paranoid:
```python
try:
    print_pgn_game_record(config, game, board, engine, start_datetime)
except Exception:
    pass
```

Closes #175