### PR TITLE
Simplify dict get

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -32,7 +32,7 @@ def create_engine(config):
     else:
         raise ValueError(
             f"    Invalid engine type: {engine_type}. Expected xboard, uci, or homemade.")
-    options = remove_managed_options(cfg.get(f"{engine_type}_options", {}) or {})
+    options = remove_managed_options(cfg.get(f"{engine_type}_options") or {})
     return Engine(commands, options, stderr, draw_or_resign, cwd=engine_working_dir)
 
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -107,7 +107,7 @@ def start(li, user_profile, engine_factory, config, logging_level, log_filename,
     control_queue = manager.Queue()
     control_stream = multiprocessing.Process(target=watch_control_stream, args=[control_queue, li])
     control_stream.start()
-    correspondence_cfg = config.get("correspondence", {}) or {}
+    correspondence_cfg = config.get("correspondence") or {}
     correspondence_checkin_period = correspondence_cfg.get("checkin_period", 600)
     correspondence_pinger = multiprocessing.Process(target=do_correspondence_ping, args=[control_queue, correspondence_checkin_period])
     correspondence_pinger.start()
@@ -249,7 +249,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     logger.info(f"+++ {game}")
 
     is_correspondence = game.perf_name == "Correspondence"
-    correspondence_cfg = config.get("correspondence", {}) or {}
+    correspondence_cfg = config.get("correspondence") or {}
     correspondence_move_time = correspondence_cfg.get("move_time", 60) * 1000
 
     engine_cfg = config["engine"]
@@ -261,7 +261,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
     online_moves_cfg = engine_cfg.get("online_moves", {})
     draw_or_resign_cfg = engine_cfg.get("draw_or_resign") or {}
 
-    greeting_cfg = config.get("greeting", {}) or {}
+    greeting_cfg = config.get("greeting") or {}
     keyword_map = defaultdict(str, me=game.me.name, opponent=game.opponent.name)
     get_greeting = lambda greeting: str(greeting_cfg.get(greeting, "") or "").format_map(keyword_map)
     hello = get_greeting("hello")

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -263,7 +263,7 @@ def play_game(li, game_id, control_queue, engine_factory, user_profile, config, 
 
     greeting_cfg = config.get("greeting") or {}
     keyword_map = defaultdict(str, me=game.me.name, opponent=game.opponent.name)
-    get_greeting = lambda greeting: str(greeting_cfg.get(greeting, "") or "").format_map(keyword_map)
+    get_greeting = lambda greeting: str(greeting_cfg.get(greeting) or "").format_map(keyword_map)
     hello = get_greeting("hello")
     goodbye = get_greeting("goodbye")
 

--- a/model.py
+++ b/model.py
@@ -67,7 +67,7 @@ class Game:
         self.username = username
         self.id = json.get("id")
         self.speed = json.get("speed")
-        clock = json.get("clock", {}) or {}
+        clock = json.get("clock") or {}
         self.clock_initial = clock.get("initial", 1000 * 3600 * 24 * 365 * 10)  # unlimited = 10 years
         self.clock_increment = clock.get("increment", 0)
         self.perf_name = json.get("perf").get("name") if json.get("perf") else "{perf?}"


### PR DESCRIPTION
Replace the pattern `dict.get(key, default) or default` with `dict.get(key) or default`. This should be functionally equivalent and reduce the length of lines.

- If `key` does not appear in the `dict`, then `get()` returns `None` and the `default` is used.
- If `key` does appear and the result is `None`, `""`, `[]`, `{}`, or similar, then the default is used. This will happen if a configuration appears in a JSON file but no value is written.
- If `key` does appear and has a value, then that value will be used.

This pattern is primarily for replacing `None` values from `dict.get()` with empty values of the appropriate type.