### PR TITLE
Support changing engine for each variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ pip install -r requirements.txt
 ## Setup Engine
 Within the file `config.yml`:
 - Enter the directory containing the engine executable in the `engine: dir` field.
-- Enter the executable name in the `engine: name` field (In Windows you may need to type a name with ".exe", like "lczero.exe")
-- If you want the engine to run in a different directory (e.g., if the engine needs to read or write files at a certain location), enter that directory in the `engine: working_dir` field.
+- Enter the executable name in the `engine: name` field, under the respective variant name (In Windows you may need to type a name with ".exe", like "lczero.exe")
+- If you want the engine to run in a different directory (e.g., if the engine needs to read or write files at a certain location), enter that directory in the `engine: working_dir` field, under the respective variant name.
   - If this field is blank or missing, the current directory will be used.
 - Leave the `weights` field empty or see [LeelaChessZero section](#leelachesszero) for Neural Nets
 
@@ -137,13 +137,14 @@ option name Use NNUE type check default true
 option name EvalFile type string default nn-62ef826d1a6d.nnue
 uciok
 ```
-Any of the names following `option name` can be listed in `uci_options` in order to configure the Stockfish engine.
+Any of the names following `option name` can be listed in `uci_options` under the respective variant name (`standard` in this case) in order to configure the Stockfish engine.
 ```yml
   uci_options:
-    Move Overhead: 100
-    Skill Level: 10
+    standard:
+      Move Overhead: 100
+      Skill Level: 10
 ```
-The exception to this are the options `uci_chess960`, `uci_variant`, `multipv`, and `ponder`. These will be handled by lichess-bot after a game starts and should not be listed in `config.yml`. Also, if an option is listed under `uci_options` that is not in the list printed by the engine, it will cause an error when the engine starts because the engine won't understand the option. The word after `type` indicates the expected type of the options: `string` for a text string, `spin` for a numeric value, `check` for a boolean True/False value.
+The exception to this are the options `uci_chess960`, `uci_variant`, `multipv`, and `ponder`. These will be handled by lichess-bot after a game starts and should not be listed in `config.yml`. Also, if an option is listed under `uci_options`, under a particular variant name, that is not in the list printed by the engine, it will cause an error when the engine starts because the engine won't understand the option. The word after `type` indicates the expected type of the options: `string` for a text string, `spin` for a numeric value, `check` for a boolean True/False value. Also do make sure to set UCI options under the correct variant name.
 
 One last option is `go_commands`. Beneath this option, arguments to the UCI `go` command can be passed. For example,
 ```yml

--- a/config.py
+++ b/config.py
@@ -42,11 +42,11 @@ def load_config(config_file):
         if not os.path.isdir(CONFIG["engine"]["dir"]):
             raise Exception(f'Your engine directory `{CONFIG["engine"]["dir"]}` is not a directory.')
 
-        working_dir = CONFIG["engine"].get("working_dir")
+        working_dir = CONFIG["engine"]["working_dir"].get(f"{variant.lower()}")
         if working_dir and not os.path.isdir(working_dir):
             raise Exception(f"Your engine's working directory `{working_dir}` is not a directory.")
 
-        engine = os.path.join(CONFIG["engine"]["dir"], CONFIG["engine"]["name"])
+        engine = os.path.join(CONFIG["engine"]["dir"], CONFIG["engine"]["name"][f"{variant.lower()}"])
 
         if not os.path.isfile(engine) and CONFIG["engine"]["protocol"] != "homemade":
             raise Exception("The engine %s file does not exist." % engine)

--- a/config.yml.default
+++ b/config.yml.default
@@ -3,8 +3,26 @@ url: "https://lichess.org/"  # Lichess base URL.
 
 engine:                      # Engine settings.
   dir: "./engines/"          # Directory containing the engine. This can be an absolute path or one relative to lichess-bot/.
-  name: "engine_name"        # Binary name of the engine to use.
-  working_dir: ""            # Directory where the chess engine will read and write files. If blank or missing, the current directory is used.
+  name:                      # Binary name of the engine to use in each variant.
+    standard: "standard_engine"
+#   chess960: "chess960_engine"
+#   antichess: "antichess_engine"
+#   atomic: "atomic_engine"
+#   crazyhouse: "crazyhouse_engine"
+#   horde: "horde_engine"
+#   kingofthehill: "kingofthehill_engine"
+#   racingkings: "racingkings_engine"
+#   threecheck: "threecheck_engine"
+  working_dir:               # Directory where the chess engine will read and write files. If blank or missing, the current directory is used.
+    standard: ""
+#   chess960: ""
+#   antichess: ""
+#   atomic: ""
+#   crazyhouse: ""
+#   horde: ""
+#   kingofthehill: ""
+#   racingkings: ""
+#   threecheck: ""
   protocol: "uci"            # "uci" or "xboard"
   ponder: true               # Think on opponent's time.
   polyglot:
@@ -55,10 +73,17 @@ engine:                      # Engine settings.
 #   cpuct: 3.1
   homemade_options:
 #   Hash: 256
-  uci_options:               # Arbitrary UCI options passed to the engine.
-    Move Overhead: 100       # Increase if your bot flags games too often.
-    Threads: 2               # Max CPU threads the engine can use.
-    Hash: 256                # Max memory (in megabytes) the engine can allocate.
+  uci_options:               # Arbitrary UCI options passed to the engine in each variant.
+    standard:
+      Move Overhead: 100     # Increase if your bot flags games too often.
+      Threads: 2             # Max CPU threads the engine can use.
+      Hash: 256              # Max memory (in megabytes) the engine can allocate.
+#   atomic:
+#     Move Overhead: 100
+#     Threads: 2
+#     Hash: 256
+#   etc.
+#   Use the same pattern for 'chess960', 'antichess', 'crazyhouse', 'horde', 'kingofthehill', 'racingkings' and 'threecheck' as well.
 #   go_commands:             # Additional options to pass to the UCI go command.
 #     nodes: 1               # Search so many nodes only.
 #     depth: 5               # Search depth ply only.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -243,7 +243,7 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
     logger.debug(f"Initial state: {initial_state}")
     game = model.Game(initial_state, user_profile["username"], li.baseUrl, config.get("abort_time", 20))
 
-    engine = engine_wrapper.create_engine(config)
+    engine = engine_wrapper.create_engine(config, game.variant_name)
     engine.get_opponent_info(game)
     conversation = Conversation(game, engine, li, __version__, challenge_queue)
 

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -191,8 +191,8 @@ def test_sf():
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
     CONFIG["engine"]["dir"] = "./TEMP/"
-    CONFIG["engine"]["name"] = f"sf{file_extension}"
-    CONFIG["engine"]["uci_options"]["Threads"] = 1
+    CONFIG["engine"]["name"]["standard"] = f"sf{file_extension}"
+    CONFIG["engine"]["uci_options"]["standard"]["standard"]["Threads"] = 1
     CONFIG["pgn_directory"] = "TEMP/sf_game_record"
     stockfish_path = f"./TEMP/sf2{file_extension}"
     win = run_bot(CONFIG, logging_level, stockfish_path)
@@ -214,11 +214,11 @@ def test_lc0():
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
     CONFIG["engine"]["dir"] = "./TEMP/"
-    CONFIG["engine"]["working_dir"] = "./TEMP/"
-    CONFIG["engine"]["name"] = "lc0.exe"
-    CONFIG["engine"]["uci_options"]["Threads"] = 1
-    CONFIG["engine"]["uci_options"].pop("Hash", None)
-    CONFIG["engine"]["uci_options"].pop("Move Overhead", None)
+    CONFIG["engine"]["working_dir"]["standard"] = "./TEMP/"
+    CONFIG["engine"]["name"]["standard"] = "lc0.exe"
+    CONFIG["engine"]["uci_options"]["standard"]["Threads"] = 1
+    CONFIG["engine"]["uci_options"]["standard"].pop("Hash", None)
+    CONFIG["engine"]["uci_options"]["standard"].pop("Move Overhead", None)
     CONFIG["pgn_directory"] = "TEMP/lc0_game_record"
     stockfish_path = "./TEMP/sf2.exe"
     win = run_bot(CONFIG, logging_level, stockfish_path)
@@ -240,9 +240,9 @@ def test_sjeng():
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
     CONFIG["engine"]["dir"] = "./TEMP/"
-    CONFIG["engine"]["working_dir"] = "./TEMP/"
+    CONFIG["engine"]["working_dir"]["standard"] = "./TEMP/"
     CONFIG["engine"]["protocol"] = "xboard"
-    CONFIG["engine"]["name"] = "sjeng.exe"
+    CONFIG["engine"]["name"]["standard"] = "sjeng.exe"
     CONFIG["engine"]["ponder"] = False
     CONFIG["pgn_directory"] = "TEMP/sjeng_game_record"
     stockfish_path = "./TEMP/sf2.exe"
@@ -271,7 +271,7 @@ def test_homemade():
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
-    CONFIG["engine"]["name"] = "Stockfish"
+    CONFIG["engine"]["name"]["standard"] = "Stockfish"
     CONFIG["engine"]["protocol"] = "homemade"
     CONFIG["pgn_directory"] = "TEMP/homemade_game_record"
     stockfish_path = f"./TEMP/sf2{file_extension}"


### PR DESCRIPTION
Well since there is a trend to create a duplicate PR here goes nothing. I'd honestly expect a duplicate to be created once a review is made for this PR so till then this will stay open.

This PR allows users to change engine for each variant. Under `name` all options to set engine for each variant is present. I've even allowed for using seperate working dirs for seperate variants. This could be useful when seperate variant engines have seperate files they use that will be stored in seperate working dirs (If this is a bit too much I could remove this). In this PR users will also be able to set different UCI options for different variants (not all variant engines use the same options). I'm not sure how xboard options work with lichess bot so setting different xboard options for different variants in not possible through this PR.