### PR TITLE
Fix duplicate variation lines written to PGN file

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -748,11 +748,12 @@ def print_pgn_game_record(config, game, board, engine, start_datetime):
             commentary_moves.append(None)
 
     index_of_first_board_move_with_commentary = len(board.move_stack)
-    for index in range(len(board.move_stack)):
-        player_moves = board.move_stack[index::2]
-        if all(played == commented or commented is None for played, commented in zip(player_moves, commentary_moves)):
-            index_of_first_board_move_with_commentary = index
-            break
+    if commentary_moves:
+        for index in range(len(board.move_stack)):
+            player_moves = board.move_stack[index::2]
+            if all(played == commented or commented is None for played, commented in zip(player_moves, commentary_moves)):
+                index_of_first_board_move_with_commentary = index
+                break
 
     # Write new uncommented moves to game_record.
     current_node = game_record.game()


### PR DESCRIPTION
Previously, if a bot had no commentary for any moves, spurious variation lines
that were identical to the main line would be written to the first move in
the PGN record. This line would be copied every time lichess-bot reconnected
to a game in progress and the bot didn't play a move. This can happen when
a bot checks in on a correspondence game and no opponent moves have
been played.

The error in the code is that the index found in the changed section of
code would return 0 since the result of calling all() on an empty set is true.

This commit fixes the problem by aligning to the end of the game record
if there is no commentary.