### PR TITLE
Improvements for PGN writing

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -148,6 +148,20 @@ class EngineWrapper:
         else:
             return move_stack_index - self.comment_start_index
 
+    def comment_for_board_index(self, index):
+        comment_index = self.comment_index(index)
+        if comment_index < 0 or comment_index % 2 != 0:
+            return None
+
+        try:
+            return self.move_commentary[comment_index // 2]
+        except IndexError:
+            return None
+
+    def add_null_comment(self):
+        if self.comment_start_index is not None:
+            self.move_commentary.append(None)
+
     def print_stats(self):
         for line in self.get_stats():
             logger.info(f"{line}")

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -59,13 +59,13 @@ class GameEnding(str, Enum):
 
 
 def translate_termination(termination, board, winner_name, winner_color):
-    loser_color = ("black" if winner_color == "white" else "white").title()
     if termination == Termination.MATE:
         return f"{winner_name} mates"
     elif termination == Termination.TIMEOUT:
-        return f"{loser_color} forfeits on time"
+        return "Time forfeiture"
     elif termination == Termination.RESIGN:
-        return f"{loser_color} resigns"
+        resigner = "black" if winner_color == "white" else "white"
+        return f"{resigner.title()} resigns"
     elif termination == Termination.ABORT:
         return "Game aborted"
     elif termination == Termination.DRAW:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -142,11 +142,11 @@ class EngineWrapper:
         self.print_stats()
         return result
 
-    def first_comment_index(self, board):
+    def comment_index(self, move_stack_index):
         if self.comment_start_index is None:
-            return len(board.move_stack)
+            return -1
         else:
-            return self.comment_start_index
+            return move_stack_index - self.comment_start_index
 
     def print_stats(self):
         for line in self.get_stats():

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -59,13 +59,13 @@ class GameEnding(str, Enum):
 
 
 def translate_termination(termination, board, winner_name, winner_color):
+    loser_color = ("black" if winner_color == "white" else "white").title()
     if termination == Termination.MATE:
         return f"{winner_name} mates"
     elif termination == Termination.TIMEOUT:
-        return "Time forfeiture"
+        return f"{loser_color} forfeits on time"
     elif termination == Termination.RESIGN:
-        resigner = "black" if winner_color == "white" else "white"
-        return f"{resigner.title()} resigns"
+        return f"{loser_color} resigns"
     elif termination == Termination.ABORT:
         return "Game aborted"
     elif termination == Termination.DRAW:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -49,7 +49,6 @@ class Termination(str, Enum):
     RESIGN = "resign"
     ABORT = "aborted"
     DRAW = "draw"
-    IN_PROGRESS = "started"
 
 
 class GameEnding(str, Enum):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -727,6 +727,16 @@ def print_pgn_game_record(li, config, game, board, engine):
         pv_node = current_node.parent.add_line(commentary.get("pv", []))
         pv_node.set_eval(commentary.get("score"), commentary.get("depth"))
 
+    termination = game.state.get("status")
+    winning_color = game.state.get("winner")
+    winning_name = game.white.name if winning_color == "white" else game.black.name
+    termination_message = engine_wrapper.translate_termination(termination,
+                                                               board,
+                                                               winning_name,
+                                                               winning_color)
+    if termination_message and "mates" not in termination_message and termination != "started":
+        game_record.end().comment = termination_message
+
     with open(game_path, "w") as game_record_destination:
         pgn_writer = chess.pgn.FileExporter(game_record_destination)
         game_record.accept(pgn_writer)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -721,7 +721,7 @@ def print_pgn_game_record(li, config, game, board, engine):
     if "mates" not in terminate_message and termination != engine_wrapper.Termination.IN_PROGRESS:
         game_record.headers["Termination"] = terminate_message
 
-    # Match the engine commentary with the moves on the board
+    # Create a list of moves with engine commentary from this session
     commentary_moves = []
     for comment in engine.move_commentary:
         if "pv" in comment and len(comment["pv"]) > 0:
@@ -731,6 +731,7 @@ def print_pgn_game_record(li, config, game, board, engine):
         else:
             commentary_moves.append(None)
 
+    # Match the engine commentary with the moves on the board
     index_of_first_board_move_with_commentary = len(board.move_stack)
     if commentary_moves:
         for index in range(len(board.move_stack)):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -735,7 +735,7 @@ def print_pgn_game_record(li, config, game, board, engine):
             if lichess_node.comment:
                 if current_node.comment:
                     if current_node.comment != lichess_node.comment:
-                        current_node.comment = current_node.comment + " / " + lichess_node.comment
+                        current_node.comment = f"{current_node.comment} {lichess_node.comment}"
                 else:
                     current_node.comment = lichess_node.comment
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -727,16 +727,6 @@ def print_pgn_game_record(li, config, game, board, engine):
         pv_node = current_node.parent.add_line(commentary.get("pv", []))
         pv_node.set_eval(commentary.get("score"), commentary.get("depth"))
 
-    termination = game.state.get("status")
-    winning_color = game.state.get("winner")
-    winning_name = game.white.name if winning_color == "white" else game.black.name
-    termination_message = engine_wrapper.translate_termination(termination,
-                                                               board,
-                                                               winning_name,
-                                                               winning_color)
-    if termination_message and "mates" not in termination_message and termination != "started":
-        game_record.end().comment = termination_message
-
     with open(game_path, "w") as game_record_destination:
         pgn_writer = chess.pgn.FileExporter(game_record_destination)
         game_record.accept(pgn_writer)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -718,9 +718,10 @@ def print_pgn_game_record(li, config, game, board, engine):
     if commentary_moves:
         for index in range(len(board.move_stack)):
             player_moves = board.move_stack[index::2]
+            if len(commentary_moves) > len(player_moves):
+                break
             if all(played == commented or commented is None for played, commented in zip(player_moves, commentary_moves)):
                 index_of_first_board_move_with_commentary = index
-                break
 
     # Write new uncommented moves to game_record.
     current_node = game_record.game()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -699,7 +699,7 @@ def print_pgn_game_record(li, config, game, board, engine):
         # Recall previously written PGN file to retain engine evaluations.
         with open(game_path) as game_data:
             game_record = chess.pgn.read_game(game_data)
-        game_record.headers = lichess_game_record.headers
+        game_record.headers.update(lichess_game_record.headers)
     except FileNotFoundError:
         game_record = lichess_game_record
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -309,6 +309,8 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                             best_move = choose_move_time(engine, board, correspondence_move_time, can_ponder, draw_offered)
                         else:
                             best_move = choose_move(engine, board, game, can_ponder, draw_offered, start_time, move_overhead)
+                    else:
+                        engine.add_null_comment()
                     move_attempted = True
                     if best_move.resigned and len(board.move_stack) >= 2:
                         li.resign(game.id)
@@ -739,17 +741,10 @@ def print_pgn_game_record(li, config, game, board, engine):
                 else:
                     current_node.comment = lichess_node.comment
 
-        comment_index = engine.comment_index(index)
-        if comment_index < 0 or comment_index % 2 != 0:
-            continue
-
-        try:
-            commentary = engine.move_commentary[comment_index // 2]
-        except IndexError:
-            continue
-
-        pv_node = current_node.parent.add_line(commentary.get("pv", []))
-        pv_node.set_eval(commentary.get("score"), commentary.get("depth"))
+        commentary = engine.comment_for_board_index(index)
+        if commentary is not None:
+            pv_node = current_node.parent.add_line(commentary.get("pv", []))
+            pv_node.set_eval(commentary.get("score"), commentary.get("depth"))
 
     with open(game_path, "w") as game_record_destination:
         pgn_writer = chess.pgn.FileExporter(game_record_destination)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -694,11 +694,10 @@ def print_pgn_game_record(li, config, game, board, engine):
     game_file_name = "".join(c for c in game_file_name if c not in '<>:"/\\|?*')
     game_path = os.path.join(game_directory, game_file_name)
 
-    # If the bot got disconnected in the middle of the game, read the previously
-    # written game record to preserve bot's commentary from last play.
     lichess_game_record = chess.pgn.read_game(io.StringIO(li.get_game_pgn(game.id)))
     try:
         with open(game_path) as game_data:
+            # Recall previously written PGN file to retain engine evaluations
             game_record = chess.pgn.read_game(game_data)
         game_record.headers = lichess_game_record.headers
     except FileNotFoundError:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -696,8 +696,8 @@ def print_pgn_game_record(li, config, game, board, engine):
 
     lichess_game_record = chess.pgn.read_game(io.StringIO(li.get_game_pgn(game.id)))
     try:
+        # Recall previously written PGN file to retain engine evaluations.
         with open(game_path) as game_data:
-            # Recall previously written PGN file to retain engine evaluations
             game_record = chess.pgn.read_game(game_data)
         game_record.headers = lichess_game_record.headers
     except FileNotFoundError:
@@ -727,7 +727,6 @@ def print_pgn_game_record(li, config, game, board, engine):
         pv_node = current_node.parent.add_line(commentary.get("pv", []))
         pv_node.set_eval(commentary.get("score"), commentary.get("depth"))
 
-    # Write game_record to file.
     with open(game_path, "w") as game_record_destination:
         pgn_writer = chess.pgn.FileExporter(game_record_destination)
         game_record.accept(pgn_writer)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -689,7 +689,7 @@ def print_pgn_game_record(li, config, game, board, engine):
     except FileExistsError:
         pass
 
-    game_file_name = f"{game.white} vs {game.black} - {game.id}.pgn"
+    game_file_name = f"{game.white.name} vs {game.black.name} - {game.id}.pgn"
     game_file_name = "".join(c for c in game_file_name if c not in '<>:"/\\|?*')
     game_path = os.path.join(game_directory, game_file_name)
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -704,9 +704,6 @@ def print_pgn_game_record(li, config, game, board, engine):
     except FileNotFoundError:
         game_record = lichess_game_record
 
-    if game_record.headers.get("Termination") == "Normal":
-            game_record.headers.pop("Termination", "")
-
     # Create a list of moves with engine commentary from this session
     commentary_moves = []
     for comment in engine.move_commentary:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -703,27 +703,8 @@ def print_pgn_game_record(li, config, game, board, engine):
     except FileNotFoundError:
         game_record = lichess_game_record
 
-    # Create a list of moves with engine commentary from this session
-    commentary_moves = []
-    for comment in engine.move_commentary:
-        if "pv" in comment and len(comment["pv"]) > 0:
-            commentary_moves.append(comment["pv"][0])
-        elif "currmove" in comment:
-            commentary_moves.append(comment["currmove"])
-        else:
-            commentary_moves.append(None)
-
-    # Match the engine commentary with the moves on the board
-    index_of_first_board_move_with_commentary = len(board.move_stack)
-    if commentary_moves:
-        for index in range(len(board.move_stack)):
-            player_moves = board.move_stack[index::2]
-            if len(commentary_moves) > len(player_moves):
-                break
-            if all(played == commented or commented is None for played, commented in zip(player_moves, commentary_moves)):
-                index_of_first_board_move_with_commentary = index
-
-    # Write new uncommented moves to game_record.
+    index_of_first_board_move_with_commentary = engine.first_comment_index(board)
+    logger.info(f"first comment index: {index_of_first_board_move_with_commentary}")
     current_node = game_record.game()
     for move in board.move_stack[:index_of_first_board_move_with_commentary]:
         if not current_node.is_end() and current_node.next().move == move:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -715,7 +715,7 @@ def print_pgn_game_record(li, config, game, board, engine):
             lichess_node = lichess_node.next()
             current_node.set_clock(lichess_node.clock())
 
-        comment_index = index - engine.first_comment_index(board)
+        comment_index = engine.comment_index(index)
         if comment_index < 0 or comment_index % 2 != 0:
             continue
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -714,6 +714,12 @@ def print_pgn_game_record(li, config, game, board, engine):
         if not lichess_node.is_end():
             lichess_node = lichess_node.next()
             current_node.set_clock(lichess_node.clock())
+            if lichess_node.comment:
+                if current_node.comment:
+                    if current_node.comment != lichess_node.comment:
+                        current_node.comment = current_node.comment + " / " + lichess_node.comment
+                else:
+                    current_node.comment = lichess_node.comment
 
         comment_index = engine.comment_index(index)
         if comment_index < 0 or comment_index % 2 != 0:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -703,7 +703,6 @@ def print_pgn_game_record(li, config, game, board, engine):
     except FileNotFoundError:
         game_record = lichess_game_record
 
-    index_of_first_board_move_with_commentary = engine.first_comment_index(board)
     current_node = game_record.game()
     lichess_node = lichess_game_record.game()
     for index, move in enumerate(board.move_stack):
@@ -716,7 +715,7 @@ def print_pgn_game_record(li, config, game, board, engine):
             lichess_node = lichess_node.next()
             current_node.set_clock(lichess_node.clock())
 
-        comment_index = index - index_of_first_board_move_with_commentary
+        comment_index = index - engine.first_comment_index(board)
         if comment_index < 0 or comment_index % 2 != 0:
             continue
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -707,14 +707,17 @@ def print_pgn_game_record(li, config, game, board, engine):
     logger.info(f"first comment index: {index_of_first_board_move_with_commentary}")
     current_node = game_record.game()
     for move in board.move_stack[:index_of_first_board_move_with_commentary]:
-        if not current_node.is_end() and current_node.next().move == move:
-            current_node = current_node.next()
-        else:
+        if current_node.is_end() or current_node.next().move != move:
             current_node = current_node.add_main_variation(move)
+        else:
+            current_node = current_node.next()            
 
     # Write new commented moves to game_record.
     for index, move in enumerate(board.move_stack[index_of_first_board_move_with_commentary:]):
-        current_node = current_node.add_main_variation(move)
+        if current_node.is_end() or current_node.next().move != move:
+            current_node = current_node.add_main_variation(move)
+        else:
+            current_node = current_node.next()
 
         if index % 2 != 0:
             continue

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -717,18 +717,15 @@ def print_pgn_game_record(li, config, game, board, engine):
     index_of_first_board_move_with_commentary = engine.first_comment_index(board)
     current_node = game_record.game()
     lichess_node = lichess_game_record.game()
-    for move in board.move_stack[:index_of_first_board_move_with_commentary]:
+    for index, move in enumerate(board.move_stack):
         current_node, lichess_node = update_game_node(current_node, lichess_node, move)
 
-    # Write new commented moves to game_record.
-    for index, move in enumerate(board.move_stack[index_of_first_board_move_with_commentary:]):
-        current_node, lichess_node = update_game_node(current_node, lichess_node, move)
-
-        if index % 2 != 0:
+        comment_index = index - index_of_first_board_move_with_commentary
+        if comment_index < 0 or comment_index % 2 != 0:
             continue
 
         try:
-            commentary = engine.move_commentary[index // 2]
+            commentary = engine.move_commentary[comment_index // 2]
         except IndexError:
             continue
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -703,7 +703,10 @@ def print_pgn_game_record(li, config, game, board, engine):
     except FileNotFoundError:
         game_record = lichess_game_record
 
-    def update_game_node(current_node, lichess_node, move):
+    index_of_first_board_move_with_commentary = engine.first_comment_index(board)
+    current_node = game_record.game()
+    lichess_node = lichess_game_record.game()
+    for index, move in enumerate(board.move_stack):
         if current_node.is_end() or current_node.next().move != move:
             current_node = current_node.add_main_variation(move)
         else:
@@ -712,13 +715,6 @@ def print_pgn_game_record(li, config, game, board, engine):
         if not lichess_node.is_end():
             lichess_node = lichess_node.next()
             current_node.set_clock(lichess_node.clock())
-        return current_node, lichess_node
-
-    index_of_first_board_move_with_commentary = engine.first_comment_index(board)
-    current_node = game_record.game()
-    lichess_node = lichess_game_record.game()
-    for index, move in enumerate(board.move_stack):
-        current_node, lichess_node = update_game_node(current_node, lichess_node, move)
 
         comment_index = index - index_of_first_board_move_with_commentary
         if comment_index < 0 or comment_index % 2 != 0:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -706,11 +706,16 @@ def print_pgn_game_record(li, config, game, board, engine):
     index_of_first_board_move_with_commentary = engine.first_comment_index(board)
     logger.info(f"first comment index: {index_of_first_board_move_with_commentary}")
     current_node = game_record.game()
+    lichess_node = lichess_game_record.game()
     for move in board.move_stack[:index_of_first_board_move_with_commentary]:
         if current_node.is_end() or current_node.next().move != move:
             current_node = current_node.add_main_variation(move)
         else:
-            current_node = current_node.next()            
+            current_node = current_node.next()
+
+        if not lichess_node.is_end():
+            lichess_node = lichess_node.next()
+            current_node.set_clock(lichess_node.clock())
 
     # Write new commented moves to game_record.
     for index, move in enumerate(board.move_stack[index_of_first_board_move_with_commentary:]):
@@ -718,6 +723,10 @@ def print_pgn_game_record(li, config, game, board, engine):
             current_node = current_node.add_main_variation(move)
         else:
             current_node = current_node.next()
+
+        if not lichess_node.is_end():
+            lichess_node = lichess_node.next()
+            current_node.set_clock(lichess_node.clock())
 
         if index % 2 != 0:
             continue

--- a/lichess.py
+++ b/lichess.py
@@ -18,7 +18,8 @@ ENDPOINTS = {
     "accept": "/api/challenge/{}/accept",
     "decline": "/api/challenge/{}/decline",
     "upgrade": "/api/bot/account/upgrade",
-    "resign": "/api/bot/game/{}/resign"
+    "resign": "/api/bot/game/{}/resign",
+    "export": "/game/export/{}"
 }
 
 
@@ -45,13 +46,13 @@ class Lichess:
                           giveup=is_final,
                           backoff_log_level=logging.DEBUG,
                           giveup_log_level=logging.DEBUG)
-    def api_get(self, path, raise_for_status=True):
+    def api_get(self, path, raise_for_status=True, get_raw_text=False):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
         response = self.session.get(url, timeout=2)
         if raise_for_status:
             response.raise_for_status()
-        return response.json()
+        return response.text if get_raw_text else response.json()
 
     @backoff.on_exception(backoff.constant,
                           (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
@@ -113,3 +114,6 @@ class Lichess:
     def set_user_agent(self, username):
         self.header.update({"User-Agent": f"lichess-bot/{self.version} user:{username}"})
         self.session.headers.update(self.header)
+
+    def get_game_pgn(self, game_id):
+        return self.api_get(ENDPOINTS["export"].format(game_id), get_raw_text=True)

--- a/lichess.py
+++ b/lichess.py
@@ -46,10 +46,10 @@ class Lichess:
                           giveup=is_final,
                           backoff_log_level=logging.DEBUG,
                           giveup_log_level=logging.DEBUG)
-    def api_get(self, path, raise_for_status=True, get_raw_text=False):
+    def api_get(self, path, raise_for_status=True, get_raw_text=False, params=None):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        response = self.session.get(url, timeout=2)
+        response = self.session.get(url, timeout=2, params=params)
         if raise_for_status:
             response.raise_for_status()
         return response.text if get_raw_text else response.json()
@@ -116,4 +116,6 @@ class Lichess:
         self.session.headers.update(self.header)
 
     def get_game_pgn(self, game_id):
-        return self.api_get(ENDPOINTS["export"].format(game_id), get_raw_text=True)
+        return self.api_get(ENDPOINTS["export"].format(game_id),
+                            get_raw_text=True,
+                            params={"literate": "true"})

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -164,3 +164,16 @@ class Lichess:
     def set_user_agent(self, username):
         self.header.update({"User-Agent": f"lichess-bot/{self.version} user:{username}"})
         self.session.headers.update(self.header)
+
+    def get_game_pgn(self, game_id):
+        return """
+[Event "Test game"]
+[Site "pytest"]
+[Date "2022.03.11"]
+[Round "1"]
+[White "Engine"]
+[Black "Engine"]
+[Result "0-1"]
+
+*
+"""                  

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -199,7 +199,7 @@ def test_sf():
     shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing SF")
     assert win == "1"
-    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "bo vs b - zzzzzzzz.pgn"))
 
 
 @pytest.mark.timeout(150, method="thread")
@@ -225,7 +225,7 @@ def test_lc0():
     shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing LC0")
     assert win == "1"
-    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "bo vs b - zzzzzzzz.pgn"))
 
 
 @pytest.mark.timeout(150, method="thread")
@@ -250,7 +250,7 @@ def test_sjeng():
     shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing Sjeng")
     assert win == "1"
-    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "bo vs b - zzzzzzzz.pgn"))
 
 
 @pytest.mark.timeout(150, method="thread")
@@ -281,4 +281,4 @@ def test_homemade():
         file.write(original_strategies)
     lichess_bot.logger.info("Finished Testing Homemade")
     assert win == "1"
-    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "BOT bo(3000) vs BOT b(3000) - zzzzzzzz.pgn"))
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"], "bo vs b - zzzzzzzz.pgn"))


### PR DESCRIPTION
1. Download PGN record from lichess.org. The lichess record includes more detailed header info (like opening identification) and extra move info like time remaining on clock.
2. Simplify `print_pgn_game_record()` code. The resulting function code is much simpler, especially the alignment of new move comments from engines after disconnecting from a game.
3. File names only include the players' names, not their titles and ratings.