### PR TITLE
Print debugging message for missing endgame tablebase paths

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -229,7 +229,10 @@ class XBoardEngine(EngineWrapper):
         features = self.engine.protocol.features
         egt_types_from_engine = features["egt"].split(",") if "egt" in features else []
         for egt_type in egt_types_from_engine:
-            options[f"egtpath {egt_type}"] = egt_paths[egt_type]
+            if egt_type in egt_paths:
+                options[f"egtpath {egt_type}"] = egt_paths[egt_type]
+            else:
+                logger.debug(f"No paths found for egt type: {egt_type}.")
         self.engine.configure(options)
 
     def report_game_result(self, game, board):


### PR DESCRIPTION
When an Xboard engine indicates that it can read endgame tablebase
books with the egt= feature, print a debugging message when a path
to that type of egt is not present in the bot's config file.

Inspired by issue #462