### PR TITLE
Add go commands to all moves

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -110,7 +110,7 @@ class EngineWrapper:
 
     def add_go_commands(self, time_limit):
         movetime = self.go_commands.get("movetime")
-        if movetime is not None and (time_limit.movetime is None or time_limit.movetime > movetime):
+        if movetime is not None and (time_limit.time is None or time_limit.time < movetime):
             time_limit.time = float(movetime) / 1000
         time_limit.depth = self.go_commands.get("depth")
         time_limit.nodes = self.go_commands.get("nodes")

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -110,8 +110,10 @@ class EngineWrapper:
 
     def add_go_commands(self, time_limit):
         movetime = self.go_commands.get("movetime")
-        if movetime is not None and (time_limit.time is None or time_limit.time < movetime):
-            time_limit.time = float(movetime) / 1000
+        if movetime is not None:
+            movetime_sec = float(movetime) / 1000
+            if time_limit.time is None or time_limit.time > movetime_sec:
+                time_limit.time = movetime_sec
         time_limit.depth = self.go_commands.get("depth")
         time_limit.nodes = self.go_commands.get("nodes")
         return time_limit

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -111,7 +111,7 @@ class EngineWrapper:
     def add_go_commands(self, time_limit):
         movetime = self.go_commands.get("movetime")
         if movetime is not None and (time_limit.movetime is None or time_limit.movetime > movetime):
-            time_limit.movetime = float(movetime) / 1000
+            time_limit.time = float(movetime) / 1000
         time_limit.depth = self.go_commands.get("depth")
         time_limit.nodes = self.go_commands.get("nodes")       
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -114,6 +114,7 @@ class EngineWrapper:
             time_limit.time = float(movetime) / 1000
         time_limit.depth = self.go_commands.get("depth")
         time_limit.nodes = self.go_commands.get("nodes")
+        return time_limit
 
     def offer_draw_or_resign(self, result, board):
         if self.draw_or_resign.get("offer_draw_enabled", False) and len(self.scores) >= self.draw_or_resign.get("offer_draw_moves", 5):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -113,7 +113,7 @@ class EngineWrapper:
         if movetime is not None and (time_limit.movetime is None or time_limit.movetime > movetime):
             time_limit.time = float(movetime) / 1000
         time_limit.depth = self.go_commands.get("depth")
-        time_limit.nodes = self.go_commands.get("nodes")       
+        time_limit.nodes = self.go_commands.get("nodes")
 
     def offer_draw_or_resign(self, result, board):
         if self.draw_or_resign.get("offer_draw_enabled", False) and len(self.scores) >= self.draw_or_resign.get("offer_draw_moves", 5):

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -95,25 +95,25 @@ class EngineWrapper:
         self.comment_start_index = None
 
     def search_for(self, board, movetime, ponder, draw_offered):
-        return self.search(board, chess.engine.Limit(time=movetime // 1000), ponder, draw_offered)
+        return self.search(board, chess.engine.Limit(time=movetime / 1000), ponder, draw_offered)
 
     def first_search(self, board, movetime, draw_offered):
         # No pondering after the first move since a different clock is used afterwards.
-        return self.search(board, chess.engine.Limit(time=movetime // 1000), False, draw_offered)
+        return self.search_for(board, movetime, False, draw_offered)
 
     def search_with_ponder(self, board, wtime, btime, winc, binc, ponder, draw_offered):
-        cmds = self.go_commands
-        movetime = cmds.get("movetime")
-        if movetime is not None:
-            movetime = float(movetime) / 1000
         time_limit = chess.engine.Limit(white_clock=wtime / 1000,
                                         black_clock=btime / 1000,
                                         white_inc=winc / 1000,
-                                        black_inc=binc / 1000,
-                                        depth=cmds.get("depth"),
-                                        nodes=cmds.get("nodes"),
-                                        time=movetime)
+                                        black_inc=binc / 1000)
         return self.search(board, time_limit, ponder, draw_offered)
+
+    def add_go_commands(self, time_limit):
+        movetime = self.go_commands.get("movetime")
+        if movetime is not None and (time_limit.movetime is None or time_limit.movetime > movetime):
+            time_limit.movetime = float(movetime) / 1000
+        time_limit.depth = self.go_commands.get("depth")
+        time_limit.nodes = self.go_commands.get("nodes")       
 
     def offer_draw_or_resign(self, result, board):
         if self.draw_or_resign.get("offer_draw_enabled", False) and len(self.scores) >= self.draw_or_resign.get("offer_draw_moves", 5):
@@ -131,6 +131,7 @@ class EngineWrapper:
         return result
 
     def search(self, board, time_limit, ponder, draw_offered):
+        time_limit = self.add_go_commands(time_limit)
         result = self.engine.play(board, time_limit, info=chess.engine.INFO_ALL, ponder=ponder, draw_offered=draw_offered)
         self.last_move_info = result.info.copy()
         self.move_commentary.append(self.last_move_info.copy())


### PR DESCRIPTION
The go commands from the user's config.yml file are not used during the first move of a game nor during correspondence games. This PR fixes that.

Other features, replace integer division (`//`) with normal division (`/`) so that move times are printed with sub-second accuracy.

Closes #466 