### PR TITLE
Add matchmaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ matchmaking:
   challenge_interval: 30
   challenge_initial_time: 60
   challenge_increment: 3
-#  challenge_days: 2
+# challenge_days: 2
   opponent_min_rating: 2000
   opponent_max_rating: 3000
   challenge_mode: "random"

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 - `matchmaking`: Challenge a random bot.
   - `allow_matchmaking`: Whether to challenge other bots.
   - `challenge_variant`: The variant for the challenges. If set to `random` a variant from the ones enabled in `challenge.variants` will be chosen on random.
-  - `challenge_interval`: How often to challenge a bot (in minutes).
+  - `challenge_timeout`: The time (in minutes) the bot has to be idle before it creates a challenge.
   - `challenge_initial_time`: The initial time (in seconds) for the challenges.
   - `challenge_increment`: The increment (in seconds) for the challenges.
   - `challenge_days`: The days for a correspondence challenge. If this option is enabled, a correspondence challenge will be created even if `challenge_initial_time` is enabled.
@@ -245,7 +245,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 matchmaking:
   allow_matchmaking: false
   challenge_variant: "random"
-  challenge_interval: 30
+  challenge_timeout: 30
   challenge_initial_time: 60
   challenge_increment: 3
 # challenge_days: 2

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 ```
 - `matchmaking`: Challenge a random bot.
   - `allow_matchmaking`: Whether to challenge other bots.
+  - `challenge_variant`: The variant for the challenges. If set to `random` a variant from the ones enabled in `challenge.variants` will be chosen on random.
   - `challenge_interval`: How often to challenge a bot (in minutes).
   - `challenge_initial_time`: The initial time (in seconds) for the challenges.
   - `challenge_increment`: The increment (in seconds) for the challenges.
@@ -243,6 +244,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 ```yml
 matchmaking:
   allow_matchmaking: false
+  challenge_variant: "random"
   challenge_interval: 30
   challenge_initial_time: 60
   challenge_increment: 3

--- a/README.md
+++ b/README.md
@@ -219,17 +219,38 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     -rated
     -casual
 ```
-  - `greeting`: Send messages via chat to the bot's opponent. The string `{me}` will be replaced by the bot's lichess account name. The string `{opponent}` will be replaced by the opponent's lichess account name. Any other word between curly brackets will be removed. If you want to put a curly bracket in the message, use two: `{{` or `}}`.
-    - `hello`: Message to send to opponent before the bot makes its first move.
-    - `goodbye`: Message to send to opponent once the game is over.
+- `greeting`: Send messages via chat to the bot's opponent. The string `{me}` will be replaced by the bot's lichess account name. The string `{opponent}` will be replaced by the opponent's lichess account name. Any other word between curly brackets will be removed. If you want to put a curly bracket in the message, use two: `{{` or `}}`.
+  - `hello`: Message to send to opponent before the bot makes its first move.
+  - `goodbye`: Message to send to opponent once the game is over.
 ```yml
   greeting:
     hello: Hi, {opponent}! I'm {me}. Good luck!
     goodbye: Good game!
 ```
-  - `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. The score is written with a tag of the form `[%eval s,d]`, where `s` is the score in pawns (positive means white has the advantage), and `d` is the depth of the search. Each game will be written to a uniquely named file.
+- `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. The score is written with a tag of the form `[%eval s,d]`, where `s` is the score in pawns (positive means white has the advantage), and `d` is the depth of the search. Each game will be written to a uniquely named file.
 ```yml
   pgn_directory: "game_records"
+```
+- `matchmaking`: Challenge a random bot.
+  - `allow_matchmaking`: Whether to challenge other bots.
+  - `challenge_interval`: How often to challenge a bot.
+  - `challenge_initial_time`: The initial time (in seconds) for the challenges.
+  - `challenge_increment`: The increment (in seconds) for the challenges.
+  - `challenge_days`: The days for a correspondence challenge. If this option is enabled, a correspondence challenge will be created even if `challenge_initial_time` is enabled.
+  - `opponent_min_rating`: The minimum rating of the opponent bot.
+  - `opponent_max_rating`: The maximum rating of the opponent bot.
+  - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
+```yml
+matchmaking:
+  allow_matchmaking: false
+  challenge_interval: 30
+  challenge_initial_time: 60
+  challenge_increment: 3
+#  challenge_days: 2
+  opponent_min_rating: 2000
+  opponent_max_rating: 3000
+  challenge_mode: "random"
+
 ```
 
 ## Lichess Upgrade to Bot Account

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 ```
 - `matchmaking`: Challenge a random bot.
   - `allow_matchmaking`: Whether to challenge other bots.
-  - `challenge_interval`: How often to challenge a bot.
+  - `challenge_interval`: How often to challenge a bot (in minutes).
   - `challenge_initial_time`: The initial time (in seconds) for the challenges.
   - `challenge_increment`: The increment (in seconds) for the challenges.
   - `challenge_days`: The days for a correspondence challenge. If this option is enabled, a correspondence challenge will be created even if `challenge_initial_time` is enabled.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ matchmaking:
   opponent_min_rating: 2000
   opponent_max_rating: 3000
   challenge_mode: "random"
-
 ```
 
 ## Lichess Upgrade to Bot Account

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `challenge_initial_time`: The initial time (in seconds) for the challenges.
   - `challenge_increment`: The increment (in seconds) for the challenges.
   - `challenge_days`: The days for a correspondence challenge. If this option is enabled, a correspondence challenge will be created even if `challenge_initial_time` is enabled.
-  - `opponent_min_rating`: The minimum rating of the opponent bot.
-  - `opponent_max_rating`: The maximum rating of the opponent bot.
+  - `opponent_min_rating`: The minimum rating of the opponent bot. The minimum rating in lichess is 600.
+  - `opponent_max_rating`: The maximum rating of the opponent bot. The maximum rating in lichess is 4000.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
 ```yml
 matchmaking:
@@ -247,8 +247,8 @@ matchmaking:
   challenge_initial_time: 60
   challenge_increment: 3
 # challenge_days: 2
-  opponent_min_rating: 2000
-  opponent_max_rating: 3000
+  opponent_min_rating: 600
+  opponent_max_rating: 4000
   challenge_mode: "random"
 ```
 

--- a/config.yml.default
+++ b/config.yml.default
@@ -133,6 +133,6 @@ matchmaking:
   challenge_initial_time: 60  # Initial time in seconds of the challenge.
   challenge_increment: 3      # Increment in seconds of the challenge.
 # challenge_days: 2           # Days for correspondence challenge. If this option is enabled, a correspondence challenge will be created even if 'challenge_initial_time' is enabled.
-  opponent_min_rating: 2000   # Opponents rating should be above this value
-  opponent_max_rating: 3000   # Opponents rating should be below this value
+  opponent_min_rating: 600    # Opponents rating should be above this value (600 is the minimum rating in lichess).
+  opponent_max_rating: 4000   # Opponents rating should be below this value (4000 is the maximum rating in lichess).
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.

--- a/config.yml.default
+++ b/config.yml.default
@@ -129,6 +129,7 @@ greeting:
 
 matchmaking:
   allow_matchmaking: false    # Set it to 'true' to challenge other bot in a set interval, time control and range.
+  challenge_variant: "random" # If set to 'random', the bot will choose one variant from the variants enabled in 'challenge.variants'.
   challenge_interval: 30      # Interval in minutes between two challenges.
   challenge_initial_time: 60  # Initial time in seconds of the challenge.
   challenge_increment: 3      # Increment in seconds of the challenge.

--- a/config.yml.default
+++ b/config.yml.default
@@ -132,7 +132,7 @@ matchmaking:
   challenge_interval: 30      # Interval in minutes between two challenges.
   challenge_initial_time: 60  # Initial time in seconds of the challenge.
   challenge_increment: 3      # Increment in seconds of the challenge.
-# challenge_days: 2          # Days for correspondence challenge. If this option is enabled, a correspondence challenge will be created even if 'challenge_initial_time' is enabled.
+# challenge_days: 2           # Days for correspondence challenge. If this option is enabled, a correspondence challenge will be created even if 'challenge_initial_time' is enabled.
   opponent_min_rating: 2000   # Opponents rating should be above this value
   opponent_max_rating: 3000   # Opponents rating should be below this value
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.

--- a/config.yml.default
+++ b/config.yml.default
@@ -132,7 +132,7 @@ matchmaking:
   challenge_interval: 30      # Interval in minutes between two challenges.
   challenge_initial_time: 60  # Initial time in seconds of the challenge.
   challenge_increment: 3      # Increment in seconds of the challenge.
-#  challenge_days: 2          # Days for correspondence challenge. If this option is enabled, a correspondence challenge will be created even if 'challenge_initial_time' is enabled.
+# challenge_days: 2          # Days for correspondence challenge. If this option is enabled, a correspondence challenge will be created even if 'challenge_initial_time' is enabled.
   opponent_min_rating: 2000   # Opponents rating should be above this value
   opponent_max_rating: 3000   # Opponents rating should be below this value
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.

--- a/config.yml.default
+++ b/config.yml.default
@@ -126,3 +126,13 @@ greeting:
     goodbye: "Good game!" # Message to send to chat at the end of a game
 
 # pgn_directory: "game_records" # A directory where PGN-format records of the bot's games are kept
+
+matchmaking:
+  allow_matchmaking: false    # Set it to 'true' to challenge other bot in a set interval, time control and range.
+  challenge_interval: 30      # Interval in minutes between two challenges.
+  challenge_initial_time: 60  # Initial time in seconds of the challenge.
+  challenge_increment: 3      # Increment in seconds of the challenge.
+#  challenge_days: 2          # Days for correspondence challenge. If this option is enabled, a correspondence challenge will be created even if 'challenge_initial_time' is enabled.
+  opponent_min_rating: 2000   # Opponents rating should be above this value
+  opponent_max_rating: 3000   # Opponents rating should be below this value
+  challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.

--- a/config.yml.default
+++ b/config.yml.default
@@ -128,9 +128,9 @@ greeting:
 # pgn_directory: "game_records" # A directory where PGN-format records of the bot's games are kept
 
 matchmaking:
-  allow_matchmaking: false    # Set it to 'true' to challenge other bot in a set interval, time control and range.
+  allow_matchmaking: false    # Set it to 'true' to challenge other bots.
   challenge_variant: "random" # If set to 'random', the bot will choose one variant from the variants enabled in 'challenge.variants'.
-  challenge_interval: 30      # Interval in minutes between two challenges.
+  challenge_timeout: 30       # Create a challenge after being idle for 'challenge_timeout' minutes.
   challenge_initial_time: 60  # Initial time in seconds of the challenge.
   challenge_increment: 3      # Increment in seconds of the challenge.
 # challenge_days: 2           # Days for correspondence challenge. If this option is enabled, a correspondence challenge will be created even if 'challenge_initial_time' is enabled.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -147,6 +147,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 break
             elif event["type"] == "local_game_done":
                 busy_processes -= 1
+                matchmaking.last_game_ended = time.time()
                 logger.info(f"+++ Process Free. Total Queued: {queued_processes}. Total Used: {busy_processes}")
                 if one_game:
                     break
@@ -224,7 +225,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                         logger.info(f"Skip missing {chlng}")
                     queued_processes -= 1
 
-            if queued_processes + busy_processes < max_games and not challenge_queue and matchmaker.should_create_challenge():
+            if queued_processes + busy_processes < min(max_games, 1) and not challenge_queue and matchmaker.should_create_challenge():
                 logger.info("Challenging a random bot")
                 matchmaker.challenge()
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -147,7 +147,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 break
             elif event["type"] == "local_game_done":
                 busy_processes -= 1
-                matchmaking.last_game_ended = time.time()
+                matchmaker.last_game_ended = time.time()
                 logger.info(f"+++ Process Free. Total Queued: {queued_processes}. Total Used: {busy_processes}")
                 if one_game:
                     break

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -225,7 +225,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                     queued_processes -= 1
 
             if queued_processes + busy_processes < max_games and not challenge_queue and matchmaker.should_create_challenge():
-                logger.debug("Challenging a random bot")
+                logger.info("Challenging a random bot")
                 matchmaker.challenge()
 
             control_queue.task_done()

--- a/lichess.py
+++ b/lichess.py
@@ -22,7 +22,8 @@ ENDPOINTS = {
     "resign": "/api/bot/game/{}/resign",
     "export": "/game/export/{}",
     "online_bots": "/api/bot/online",
-    "challenge": "/api/challenge/{}"
+    "challenge": "/api/challenge/{}",
+    "cancel": "/api/challenge/{}/cancel"
 }
 
 
@@ -132,3 +133,6 @@ class Lichess:
 
     def challenge(self, username, params):
         return self.api_post(ENDPOINTS["challenge"].format(username), payload=params, raise_for_status=False)
+
+    def cancel(self, challenge_id):
+        return self.api_post(ENDPOINTS["cancel"].format(challenge_id), raise_for_status=False)

--- a/lichess.py
+++ b/lichess.py
@@ -55,6 +55,7 @@ class Lichess:
         response = self.session.get(url, timeout=2, params=params)
         if raise_for_status:
             response.raise_for_status()
+        response.encoding = "utf-8"
         return response.text if get_raw_text else response.json()
 
     @backoff.on_exception(backoff.constant,

--- a/lichess.py
+++ b/lichess.py
@@ -1,3 +1,4 @@
+import json
 import requests
 from urllib.parse import urljoin
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
@@ -19,7 +20,9 @@ ENDPOINTS = {
     "decline": "/api/challenge/{}/decline",
     "upgrade": "/api/bot/account/upgrade",
     "resign": "/api/bot/game/{}/resign",
-    "export": "/game/export/{}"
+    "export": "/game/export/{}",
+    "online_bots": "/api/bot/online",
+    "challenge": "/api/challenge/{}"
 }
 
 
@@ -61,11 +64,12 @@ class Lichess:
                           giveup=is_final,
                           backoff_log_level=logging.DEBUG,
                           giveup_log_level=logging.DEBUG)
-    def api_post(self, path, data=None, headers=None, params=None):
+    def api_post(self, path, data=None, headers=None, params=None, payload=None, raise_for_status=True):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        response = self.session.post(url, data=data, headers=headers, params=params, timeout=2)
-        response.raise_for_status()
+        response = self.session.post(url, data=data, headers=headers, params=params, json=payload, timeout=2)
+        if raise_for_status:
+            response.raise_for_status()
         return response.json()
 
     def get_game(self, game_id):
@@ -119,3 +123,11 @@ class Lichess:
         return self.api_get(ENDPOINTS["export"].format(game_id),
                             get_raw_text=True,
                             params={"literate": "true"})
+
+    def get_online_bots(self):
+        online_bots = self.api_get(ENDPOINTS["online_bots"], get_raw_text=True)
+        online_bots = list(filter(bool, online_bots.split("\n")))
+        return list(map(lambda bot: json.loads(bot), online_bots))
+
+    def challenge(self, username, params):
+        return self.api_post(ENDPOINTS["challenge"].format(username), payload=params, raise_for_status=False)

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -15,11 +15,12 @@ class Matchmaking:
         self.username = username
         self.last_challenge_created = time.time()
         self.challenge_expire_time = 25  # The challenge expires 20 seconds after creating it.
+        self.challenge_id = None
 
-    def should_create_challenge(self, challenge_id):
+    def should_create_challenge(self):
         matchmaking_enabled = self.matchmaking_cfg.get("allow_matchmaking")
         time_has_passed = self.last_challenge_created + ((self.matchmaking_cfg.get("challenge_interval") or 30) * 60) < time.time()
-        challenge_expired = self.last_challenge_created + self.challenge_expire_time < time.time() and challenge_id
+        challenge_expired = self.last_challenge_created + self.challenge_expire_time < time.time() and self.challenge_id
         return matchmaking_enabled and (time_has_passed or challenge_expired)
 
     def create_challenge(self, username, base_time, increment, days, variant):
@@ -70,4 +71,4 @@ class Matchmaking:
         logger.debug(f"Challenge id is {challenge_id}.")
         if challenge_id:
             self.last_challenge_created = time.time()
-        return challenge_id
+        self.challenge_id = challenge_id

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -58,7 +58,9 @@ class Matchmaking:
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 3000
 
         online_bots = self.li.get_online_bots()
-        online_bots = list(filter(lambda bot: bot["username"] != self.username and not bot.get("disabled") and min_rating <= ((bot["perfs"].get(game_type) or {}).get("rating") or 0) <= max_rating, online_bots))
+        online_bots = list(filter(lambda bot: bot["username"] != self.username and not bot.get("disabled") and
+                                  min_rating <= ((bot["perfs"].get(game_type) or {}).get("rating") or 0) <= max_rating,
+                                  online_bots))
         bot_username = random.choice(online_bots)["username"] if online_bots else None
         return bot_username, base_time, increment, days, variant
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -55,7 +55,7 @@ class Matchmaking:
             game_type = "classical"
 
         min_rating = self.matchmaking_cfg.get("opponent_min_rating", 600)
-        max_rating = self.matchmaking_cfg.get("opponent_max_rating", 4000)
+        max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
 
         online_bots = self.li.get_online_bots()
         online_bots = list(filter(lambda bot: bot["username"] != self.username and not bot.get("disabled") and

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -54,8 +54,8 @@ class Matchmaking:
         else:
             game_type = "classical"
 
-        min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 2000
-        max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 3000
+        min_rating = self.matchmaking_cfg.get("opponent_min_rating", 600)
+        max_rating = self.matchmaking_cfg.get("opponent_max_rating", 4000)
 
         online_bots = self.li.get_online_bots()
         online_bots = list(filter(lambda bot: bot["username"] != self.username and not bot.get("disabled") and

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -19,6 +19,8 @@ class Matchmaking:
         matchmaking_enabled = self.matchmaking_cfg.get("allow_matchmaking")
         time_has_passed = self.last_challenge_created + ((self.matchmaking_cfg.get("challenge_interval") or 30) * 60) < time.time()
         challenge_expired = self.last_challenge_created + self.challenge_expire_time < time.time() and self.challenge_id
+        if challenge_expired:
+            self.li.cancel(self.challenge_id)
         return matchmaking_enabled and (time_has_passed or challenge_expired)
 
     def create_challenge(self, username, base_time, increment, days, variant):

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -19,12 +19,12 @@ class Matchmaking:
         matchmaking_enabled = self.matchmaking_cfg.get("allow_matchmaking")
         time_has_passed = self.last_challenge_created + ((self.matchmaking_cfg.get("challenge_interval") or 30) * 60) < time.time()
         challenge_expired = self.last_challenge_created + self.challenge_expire_time < time.time() and self.challenge_id
-        # Wait 10 seconds before creating a new challenge to avoid hitting the api rate limits.
-        ten_seconds_passed = self.last_challenge_created + 10 < time.time()
+        # Wait 20 seconds before creating a new challenge to avoid hitting the api rate limits.
+        twenty_seconds_passed = self.last_challenge_created + 20 < time.time()
         if challenge_expired:
             self.li.cancel(self.challenge_id)
             logger.debug(f"Challenge id {self.challenge_id} cancelled.")
-        return matchmaking_enabled and (time_has_passed or challenge_expired) and ten_seconds_passed
+        return matchmaking_enabled and (time_has_passed or challenge_expired) and twenty_seconds_passed
 
     def create_challenge(self, username, base_time, increment, days, variant):
         mode = self.matchmaking_cfg.get("challenge_mode") or "random"

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -1,0 +1,63 @@
+import random
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Matchmaking:
+    def __init__(self, li, config):
+        self.li = li
+        self.variants = config["challenge"]["variants"].copy()
+        if "fromPosition" in self.variants:
+            self.variants.pop(self.variants.index("fromPosition"))
+        if "correspondence" in self.variants:
+            self.variants.pop(self.variants.index("correspondence"))
+        self.matchmaking_cfg = config["matchmaking"]
+
+    def create_challenge(self, username, base_time, increment, days, variant):
+        mode = self.matchmaking_cfg.get("challenge_mode") or "random"
+        if mode == "random":
+            mode = random.choice(["casual", "rated"])
+        rated = mode == "rated"
+        params = {"rated": rated, "variant": variant}
+        if days:
+            params["days"] = days
+        else:
+            params["clock.limit"] = base_time
+            params["clock.increment"] = increment
+        challenge_id = self.li.challenge(username, params).get("challenge", {}).get("id")
+        return challenge_id
+
+    def choose_opponent(self):
+        variant = random.choice(self.variants)
+        base_time = self.matchmaking_cfg.get("challenge_initial_time") or 60
+        increment = self.matchmaking_cfg.get("challenge_increment") or 2
+        days = self.matchmaking_cfg.get("challenge_days")
+        game_duration = base_time + increment * 40
+        if variant != "standard":
+            game_type = variant
+        elif days:
+            game_type = "correspondence"
+        elif game_duration < 179:
+            game_type = "bullet"
+        elif game_duration < 479:
+            game_type = "blitz"
+        elif game_duration < 1499:
+            game_type = "rapid"
+        else:
+            game_type = "classical"
+
+        min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 2000
+        max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 3000
+
+        online_bots = self.li.get_online_bots()
+        online_bots = list(filter(lambda bot: min_rating <= ((bot["perfs"].get(game_type) or {}).get("rating") or 0) <= max_rating, online_bots))
+        bot_username = random.choice(online_bots)["username"] if online_bots else None
+        return bot_username, base_time, increment, days, variant
+
+    def challenge(self):
+        bot_username, base_time, increment, days, variant = self.choose_opponent()
+        logger.debug(f"Will challenge {bot_username} for a {variant} game.")
+        challenge_id = self.create_challenge(bot_username, base_time, increment, days, variant) if bot_username else None
+        logger.debug(f"Challenge id is {challenge_id}.")
+        return challenge_id

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -54,7 +54,7 @@ class Matchmaking:
         else:
             game_type = "classical"
 
-        min_rating = self.matchmaking_cfg.get("opponent_min_rating", 600)
+        min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 600
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
 
         online_bots = self.li.get_online_bots()

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -19,9 +19,11 @@ class Matchmaking:
         matchmaking_enabled = self.matchmaking_cfg.get("allow_matchmaking")
         time_has_passed = self.last_challenge_created + ((self.matchmaking_cfg.get("challenge_interval") or 30) * 60) < time.time()
         challenge_expired = self.last_challenge_created + self.challenge_expire_time < time.time() and self.challenge_id
+        # Wait 10 seconds before creating a new challenge to avoid hitting the api rate limits.
+        ten_seconds_passed = self.last_challenge_created + 10 < time.time()
         if challenge_expired:
             self.li.cancel(self.challenge_id)
-        return matchmaking_enabled and (time_has_passed or challenge_expired)
+        return matchmaking_enabled and (time_has_passed or challenge_expired) and ten_seconds_passed
 
     def create_challenge(self, username, base_time, increment, days, variant):
         mode = self.matchmaking_cfg.get("challenge_mode") or "random"

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -37,8 +37,8 @@ class Matchmaking:
 
     def choose_opponent(self):
         variant = random.choice(self.variants)
-        base_time = self.matchmaking_cfg.get("challenge_initial_time") or 60
-        increment = self.matchmaking_cfg.get("challenge_increment") or 2
+        base_time = self.matchmaking_cfg.get("challenge_initial_time", 60)
+        increment = self.matchmaking_cfg.get("challenge_increment", 2)
         days = self.matchmaking_cfg.get("challenge_days")
         game_duration = base_time + increment * 40
         if variant != "standard":

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -12,12 +12,13 @@ class Matchmaking:
         self.matchmaking_cfg = config.get("matchmaking") or {}
         self.username = username
         self.last_challenge_created = time.time()
+        self.last_game_ended = time.time()
         self.challenge_expire_time = 25  # The challenge expires 20 seconds after creating it.
         self.challenge_id = None
 
     def should_create_challenge(self):
         matchmaking_enabled = self.matchmaking_cfg.get("allow_matchmaking")
-        time_has_passed = self.last_challenge_created + ((self.matchmaking_cfg.get("challenge_interval") or 30) * 60) < time.time()
+        time_has_passed = self.last_game_ended + ((self.matchmaking_cfg.get("challenge_timeout") or 30) * 60) < time.time()
         challenge_expired = self.last_challenge_created + self.challenge_expire_time < time.time() and self.challenge_id
         # Wait 20 seconds before creating a new challenge to avoid hitting the api rate limits.
         twenty_seconds_passed = self.last_challenge_created + 20 < time.time()

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -23,6 +23,7 @@ class Matchmaking:
         ten_seconds_passed = self.last_challenge_created + 10 < time.time()
         if challenge_expired:
             self.li.cancel(self.challenge_id)
+            logger.debug(f"Challenge id {self.challenge_id} cancelled.")
         return matchmaking_enabled and (time_has_passed or challenge_expired) and ten_seconds_passed
 
     def create_challenge(self, username, base_time, increment, days, variant):
@@ -40,7 +41,9 @@ class Matchmaking:
         return challenge_id
 
     def choose_opponent(self):
-        variant = random.choice(self.variants)
+        variant = self.matchmaking_cfg.get("challenge_variant") or "random"
+        if variant == "random":
+            variant = random.choice(self.variants)
         base_time = self.matchmaking_cfg.get("challenge_initial_time", 60)
         increment = self.matchmaking_cfg.get("challenge_increment", 2)
         days = self.matchmaking_cfg.get("challenge_days")
@@ -70,9 +73,9 @@ class Matchmaking:
 
     def challenge(self):
         bot_username, base_time, increment, days, variant = self.choose_opponent()
-        logger.debug(f"Will challenge {bot_username} for a {variant} game.")
+        logger.info(f"Will challenge {bot_username} for a {variant} game.")
         challenge_id = self.create_challenge(bot_username, base_time, increment, days, variant) if bot_username else None
-        logger.debug(f"Challenge id is {challenge_id}.")
+        logger.info(f"Challenge id is {challenge_id}.")
         if challenge_id:
             self.last_challenge_created = time.time()
         self.challenge_id = challenge_id

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -10,7 +10,7 @@ class Matchmaking:
         self.variants = config["challenge"]["variants"].copy()
         if "fromPosition" in self.variants:
             self.variants.pop(self.variants.index("fromPosition"))
-        self.matchmaking_cfg = config["matchmaking"]
+        self.matchmaking_cfg = config.get("matchmaking") or {}
 
     def create_challenge(self, username, base_time, increment, days, variant):
         mode = self.matchmaking_cfg.get("challenge_mode") or "random"

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -76,6 +76,5 @@ class Matchmaking:
         logger.info(f"Will challenge {bot_username} for a {variant} game.")
         challenge_id = self.create_challenge(bot_username, base_time, increment, days, variant) if bot_username else None
         logger.info(f"Challenge id is {challenge_id}.")
-        if challenge_id:
-            self.last_challenge_created = time.time()
+        self.last_challenge_created = time.time()
         self.challenge_id = challenge_id

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -10,8 +10,6 @@ class Matchmaking:
         self.variants = config["challenge"]["variants"].copy()
         if "fromPosition" in self.variants:
             self.variants.pop(self.variants.index("fromPosition"))
-        if "correspondence" in self.variants:
-            self.variants.pop(self.variants.index("correspondence"))
         self.matchmaking_cfg = config["matchmaking"]
 
     def create_challenge(self, username, base_time, increment, days, variant):

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -8,9 +8,7 @@ logger = logging.getLogger(__name__)
 class Matchmaking:
     def __init__(self, li, config, username):
         self.li = li
-        self.variants = config["challenge"]["variants"].copy()
-        if "fromPosition" in self.variants:
-            self.variants.pop(self.variants.index("fromPosition"))
+        self.variants = list(filter(lambda variant: variant != "fromPosition", config["challenge"]["variants"]))
         self.matchmaking_cfg = config.get("matchmaking") or {}
         self.username = username
         self.last_challenge_created = time.time()

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -58,7 +58,7 @@ class Matchmaking:
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 3000
 
         online_bots = self.li.get_online_bots()
-        online_bots = list(filter(lambda bot: bot["username"] != self.username and min_rating <= ((bot["perfs"].get(game_type) or {}).get("rating") or 0) <= max_rating, online_bots))
+        online_bots = list(filter(lambda bot: bot["username"] != self.username and not bot.get("disabled") and min_rating <= ((bot["perfs"].get(game_type) or {}).get("rating") or 0) <= max_rating, online_bots))
         bot_username = random.choice(online_bots)["username"] if online_bots else None
         return bot_username, base_time, increment, days, variant
 


### PR DESCRIPTION
Adds matchmaking. The variant is chosen by random from all the supported variants. If `challenge_days` is enabled then the challenge will always be correspondence, even if it is a variant game (e.g. crazyhouse correspondence).

closes #472 