### PR TITLE
Remove dependencies not required by lichess-bot

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -22,7 +22,6 @@ import io
 from config import load_config
 from conversation import Conversation, ChatLine
 from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError, ReadTimeout
-from urllib3.exceptions import ProtocolError
 from ColorLogger import enable_color_logging
 from collections import defaultdict
 from http.client import RemoteDisconnected
@@ -348,7 +347,7 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                     if game.is_abortable():
                         li.abort(game.id)
                     break
-        except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, ProtocolError):
+        except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError):
             if move_attempted:
                 continue
             if game.id not in (ongoing_game["gameId"] for ongoing_game in li.get_ongoing_games()):

--- a/lichess.py
+++ b/lichess.py
@@ -2,7 +2,6 @@ import json
 import requests
 from urllib.parse import urljoin
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
-from urllib3.exceptions import ProtocolError
 from http.client import RemoteDisconnected
 import backoff
 import logging
@@ -44,7 +43,7 @@ class Lichess:
         return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
     @backoff.on_exception(backoff.constant,
-                          (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
+                          (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                           max_time=60,
                           interval=0.1,
                           giveup=is_final,
@@ -60,7 +59,7 @@ class Lichess:
         return response.text if get_raw_text else response.json()
 
     @backoff.on_exception(backoff.constant,
-                          (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
+                          (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                           max_time=60,
                           interval=0.1,
                           giveup=is_final,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,6 @@
-certifi==2022.6.15
-chardet==4.0.0
-idna==3.3
 chess==1.9.2
 PyYAML>=5.4.1
 requests>=2.25.1
-urllib3==1.26.9
 backoff==2.1.2
 
 # Requirements for tests

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -2,7 +2,6 @@ import logging
 import requests
 from urllib.parse import urljoin
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
-from urllib3.exceptions import ProtocolError
 from http.client import RemoteDisconnected
 import backoff
 import time
@@ -93,7 +92,7 @@ class Lichess:
         return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
     @backoff.on_exception(backoff.constant,
-                          (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
+                          (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)
@@ -105,7 +104,7 @@ class Lichess:
         return response.json()
 
     @backoff.on_exception(backoff.constant,
-                          (RemoteDisconnected, ConnectionError, ProtocolError, HTTPError, ReadTimeout),
+                          (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)


### PR DESCRIPTION
The modules that have been deleted from requirements.txt are installed
as dependencies of other modules, in this case, by requests.

The lines importing urllib3 are deleted since requests should never throw
ProtocolError. Only requests exceptions should be thrown and caught
when contacting lichess.org.