### PR TITLE
When logging to a file, keep logging to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ To output more information (including your engine's thinking output and debuggin
 python3 lichess-bot.py -v
 ```
 
+If you want to record the output to a log file, add the `-l` or `--logfile` along with a file name:
+```
+python3 lichess-bot.py --logfile log.txt
+```
+
 ## To Quit
 - Press `CTRL+C`.
 - It may take some time to quit.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -765,10 +765,10 @@ def intro():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Play on Lichess with a bot")
-    parser.add_argument("-u", action="store_true", help="Add this flag to upgrade your account to a bot account.")
-    parser.add_argument("-v", action="store_true", help="Verbose output. Changes log level from INFO to DEBUG.")
+    parser.add_argument("-u", action="store_true", help="Upgrade your account to a bot account.")
+    parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.org.")
     parser.add_argument("--config", help="Specify a configuration file (defaults to ./config.yml)")
-    parser.add_argument("-l", "--logfile", help="Log file to append logs to.", default=None)
+    parser.add_argument("-l", "--logfile", help="Record all console output to a log file.", default=None)
     args = parser.parse_args()
 
     logging_level = logging.DEBUG if args.v else logging.INFO

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -75,26 +75,27 @@ def do_correspondence_ping(control_queue, period):
         control_queue.put_nowait({"type": "correspondence_ping"})
 
 
-def logging_configurer(logger, level, filename):
-    logger.setLevel(level)
+def logging_configurer(level, filename):    
     console_handler = RichHandler()
-    console_handler.setLevel(level)
     console_formatter = logging.Formatter("%(message)s")
     console_handler.setFormatter(console_formatter)
-    logger.addHandler(console_handler)
+    all_handlers = [console_handler]
 
     if filename:
         file_handler = logging.FileHandler(filename, delay=True)
-        file_handler.setLevel(level)
         FORMAT = "%(asctime)s %(name)s %(levelname)s %(message)s"
         file_formatter = logging.Formatter(FORMAT)
         file_handler.setFormatter(file_formatter)
-        logger.addHandler(file_handler)
+        all_handlers.append(file_handler)
+
+    logging.basicConfig(level=level,
+                        handlers=all_handlers,
+                        force=True)
 
 
 def logging_listener_proc(queue, configurer, level, log_filename):
+    configurer(level, log_filename)
     logger = logging.getLogger()
-    configurer(logger, level, log_filename)
     while not terminated:
         try:
             logger.handle(queue.get())
@@ -772,7 +773,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     logging_level = logging.DEBUG if args.v else logging.INFO
-    logging_configurer(logger, logging_level, args.logfile)
+    logging_configurer(logging_level, args.logfile)
     logger.info(intro(), extra={"highlighter": None})
     CONFIG = load_config(args.config or "./config.yml")
     li = lichess.Lichess(CONFIG["token"], CONFIG["url"], __version__, logging_level)

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -63,7 +63,7 @@ if platform == "win32":
     download_lc0()
     download_sjeng()
 logging_level = lichess_bot.logging.INFO
-lichess_bot.logging_configurer(logging_level, None)
+lichess_bot.logging_configurer(lichess_bot.logger, logging_level, None)
 lichess_bot.logger.info("Downloaded engines")
 
 

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -63,7 +63,7 @@ if platform == "win32":
     download_lc0()
     download_sjeng()
 logging_level = lichess_bot.logging.INFO
-lichess_bot.logging_configurer(lichess_bot.logger, logging_level, None)
+lichess_bot.logging_configurer(logging_level, None)
 lichess_bot.logger.info("Downloaded engines")
 
 


### PR DESCRIPTION
If the user opts to record lichess-bot logs to a file (-l), the program will keep printing messages to the console. Before, lichess-bot could only log to the console or to a file, but not both.