### PR TITLE
Update setup-python and put github actions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install dependencies

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install dependencies


### PR DESCRIPTION
Update `setup-python` to `v4`.

Changes:
- Ability to download, install and set up Python packages from `actions/python-versions` that do not come preinstalled on runners.
  - Allows for pinning to a specific patch version of Python without the worry of it ever being removed or changed.
- Automatic setup and download of Python packages if using a self-hosted runner.
- Support for pre-release versions of Python.
- Support for installing any version of PyPy on-flight
- Support for built-in caching of pip, pipenv and poetry dependencies
- Support for `.python-version` file

Add github actions to `dependabot.yml`, so dependabot will make a PR every time there is a new github action update.