### PR TITLE
Fix cloud analysis bug

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -449,7 +449,7 @@ def get_chessdb_move(li, board, game, chessdb_cfg):
 
     try:
         if quality == "best":
-            data = li.api_get(f"https://www.chessdb.cn/cdb.php?action=querypv&board={board.fen()}&json=1")
+            data = li.api_get("https://www.chessdb.cn/cdb.php", params={"action": "querypv", "board": board.fen(), "json": 1})
             if data["status"] == "ok":
                 depth = data["depth"]
                 if depth >= chessdb_cfg.get("min_depth", 20):
@@ -458,13 +458,13 @@ def get_chessdb_move(li, board, game, chessdb_cfg):
                     logger.info(f"Got move {move} from chessdb.cn (depth: {depth}, score: {score})")
 
         elif quality == "good":
-            data = li.api_get(f"https://www.chessdb.cn/cdb.php?action=querybest&board={board.fen()}&json=1")
+            data = li.api_get("https://www.chessdb.cn/cdb.php", params={"action": "querybest", "board": board.fen(), "json": 1})
             if data["status"] == "ok":
                 move = data["move"]
                 logger.info(f"Got move {move} from chessdb.cn")
 
         elif quality == "all":
-            data = li.api_get(f"https://www.chessdb.cn/cdb.php?action=query&board={board.fen()}&json=1")
+            data = li.api_get("https://www.chessdb.cn/cdb.php", params={"action": "query", "board": board.fen(), "json": 1})
             if data["status"] == "ok":
                 move = data["move"]
                 logger.info(f"Got move {move} from chessdb.cn")
@@ -473,7 +473,7 @@ def get_chessdb_move(li, board, game, chessdb_cfg):
 
     if chessdb_cfg.get("contribute", True):
         try:
-            li.api_get(f"http://www.chessdb.cn/cdb.php?action=queue&board={board.fen()}&json=1")
+            li.api_get("https://www.chessdb.cn/cdb.php", params={"action": "queue", "board": board.fen(), "json": 1})
         except Exception:
             pass
 
@@ -492,7 +492,7 @@ def get_lichess_cloud_move(li, board, game, lichess_cloud_cfg):
     variant = "standard" if board.uci_variant == "chess" else board.uci_variant
 
     try:
-        data = li.api_get(f"https://lichess.org/api/cloud-eval?fen={board.fen()}&multiPv={multipv}&variant={variant}", raise_for_status=False)
+        data = li.api_get(f"https://lichess.org/api/cloud-eval", params={"fen": board.fen(), "multiPv": multipv, "variant": variant}, raise_for_status=False)
         if "error" not in data:
             if quality == "best":
                 depth = data["depth"]
@@ -537,7 +537,7 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
             name_to_wld = {"loss": -2, "maybe-loss": -1, "blessed-loss": -1, "draw": 0, "cursed-win": 1, "maybe-win": 1, "win": 2}
             max_pieces = 7 if board.uci_variant == "chess" else 6
             if pieces <= max_pieces:
-                data = li.api_get(f"http://tablebase.lichess.ovh/{variant}?fen={board.fen()}")
+                data = li.api_get(f"http://tablebase.lichess.ovh/{variant}", params={"fen": board.fen()})
                 if quality == "best":
                     move = data["moves"][0]["uci"]
                     wdl = name_to_wld[data["moves"][0]["category"]] * -1
@@ -573,14 +573,14 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
                     return 2
 
             if quality == "best":
-                data = li.api_get(f"https://www.chessdb.cn/cdb.php?action=querypv&board={board.fen()}&json=1")
+                data = li.api_get(f"https://www.chessdb.cn/cdb.php", params={"action": "querypv", "board": board.fen(), "json": 1})
                 if data["status"] == "ok":
                     score = data["score"]
                     move = data["pv"][0]
                     logger.info(f"Got move {move} from chessdb.cn (wdl: {score_to_wdl(score)})")
                     return move, score_to_wdl(score)
             else:
-                data = li.api_get(f"https://www.chessdb.cn/cdb.php?action=queryall&board={board.fen()}&json=1")
+                data = li.api_get(f"https://www.chessdb.cn/cdb.php", params={"action": "queryall", "board": board.fen(), "json": 1})
                 if data["status"] == "ok":
                     best_wdl = score_to_wdl(data["moves"][0]["score"])
                     possible_moves = list(filter(lambda possible_move: score_to_wdl(possible_move["score"]) == best_wdl, data["moves"]))


### PR DESCRIPTION
Fixes the problem described in #433. The parameters are now given in the param field and not added to the url. This only seems to have caused problems in lichess cloud analysis but chessdb was also changed. When running with `logging.DEBUG` I get the same url as when using the old way but only the new way works.
```
                    DEBUG    https://lichess.org:443 "GET connectionpool.py:452
                             /api/cloud-eval?fen=rnbqkbnr                      
                             %2Fpppppppp%2F8%2F8%2F8%2F8%                      
                             2FPPPPPPPP%2FRNBQKBNR+w+KQkq                      
                             +-+0+1+%2B0%2B0&variant=thre                      
                             eCheck&multiPv=5 HTTP/1.1"                        
                             200 None                          
```
```python
import requests

# Old way
re = requests.get("https://lichess.org/api/cloud-eval?fen=rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0&multiPv=5&variant=threeCheck").text
# {"error":"Not found"}

# New way
re = requests.get("https://lichess.org/api/cloud-eval", params={"fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0", "variant": 'threeCheck', "multiPv": 5}).text
# {"fen":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0","knodes":8192147,"depth":41,"pvs":[{"moves":"e2e4 b8c6 g1f3 e7e6 b1c3 f8b4 f1c4 g8e7 e1h1 e7g6","cp":348},{"moves":"b1c3 b8c6 g1f3 e7e5 e2e4 f8c5 d2d4 c5d4 f1c4 d4c3","cp":316},{"moves":"g1f3 e7e5 b1c3 g8f6 e2e4 f8c5 d2d4 e5d4 f1d3 d4c3","cp":106},{"moves":"g1h3 b8c6 e2e4 g8f6 b1c3 e7e6 f1e2 c6d4 e1h1 b7b5","cp":71},{"moves":"e2e3 b8c6 b1c3 g8f6 d2d4 e7e5 d4d5 f8b4 c1d2 e8h8","cp":0}]}
```