### PR TITLE
Handle non-move game updates

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -198,6 +198,9 @@ class EngineWrapper:
     def report_game_result(self, game, board):
         pass
 
+    def inform_draw(self):
+        pass
+
     def stop(self):
         pass
 
@@ -273,6 +276,10 @@ class XBoardEngine(EngineWrapper):
             self.engine.protocol.send_line(f"rating {game.me.rating} {game.opponent.rating}")
         if game.opponent.title == "BOT":
             self.engine.protocol.send_line("computer")
+
+    def inform_draw(self):
+        if self.engine.protocol.features.get("draw", 1):
+            self.engine.protocol.send_line("draw")
 
 
 def getHomemadeEngine(name):


### PR DESCRIPTION
When there are changes to the game that are not moves (draw offers
and move takeback requests), lichess sends a gameState message with
the same moves as before the request. This can sometimes cause lichess
to signal to the bot to consider the prior board position that it already
played. This update fixes this issue and adds a place for a bot to accept
its opponent's move takeback requests if configured to do so (not
implemented yet).

Fixes #502