### PR TITLE
Handle rate limit status code

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -789,7 +789,7 @@ def intro():
     """ % __version__
 
 
-if __name__ == "__main__":
+def start_lichess_bot():
     parser = argparse.ArgumentParser(description="Play on Lichess with a bot")
     parser.add_argument("-u", action="store_true", help="Upgrade your account to a bot account.")
     parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.org.")
@@ -815,3 +815,11 @@ if __name__ == "__main__":
         start(li, user_profile, CONFIG, logging_level, args.logfile)
     else:
         logger.error(f"{username} is not a bot account. Please upgrade it to a bot account!")
+
+
+if __name__ == "__main__":
+    try:
+        start_lichess_bot()
+    except Exception as error:
+        logger.error(error)
+        logger.error(game_error_handler(error))

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -40,8 +40,12 @@ class Matchmaking:
         else:
             params["clock.limit"] = base_time
             params["clock.increment"] = increment
-        challenge_id = self.li.challenge(username, params).get("challenge", {}).get("id")
-        return challenge_id
+
+        try:
+            challenge_id = self.li.challenge(username, params).get("challenge", {}).get("id")
+            return challenge_id
+        except Exception:
+            return None
 
     def choose_opponent(self):
         variant = self.matchmaking_cfg.get("challenge_variant") or "random"


### PR DESCRIPTION
If a request to lichess.org results in a status code 429, that means lichess is rate-limiting the bot, so communication with the API is temporarily cut off. Wait one minute before trying to communicate through the API again. This should really fix #501.

Reference: https://lichess.org/api#section/Introduction/Rate-limiting