### PR TITLE
Remove between-move draw offer notification

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -214,9 +214,6 @@ class EngineWrapper:
     def report_game_result(self, game, board):
         pass
 
-    def inform_draw(self):
-        pass
-
     def stop(self):
         pass
 
@@ -292,10 +289,6 @@ class XBoardEngine(EngineWrapper):
             self.engine.protocol.send_line(f"rating {game.me.rating} {game.opponent.rating}")
         if game.opponent.title == "BOT":
             self.engine.protocol.send_line("computer")
-
-    def inform_draw(self):
-        if self.engine.protocol.features.get("draw", 1):
-            self.engine.protocol.send_line("draw")
 
 
 def getHomemadeEngine(name):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -403,8 +403,6 @@ def play_game(li,
                     engine.report_game_result(game, board)
                     tell_user_game_result(game, board)
                     conversation.send_message("player", goodbye)
-                else:
-                    inform_engine_of_update(engine, game)
 
                 wb = "w" if board.turn == chess.WHITE else "b"
                 terminate_time = (upd[f"{wb}time"] + upd[f"{wb}inc"]) / 1000 + 60
@@ -778,11 +776,6 @@ def game_changed(current_game, prior_game):
         return True
 
     return current_game.state["moves"] != prior_game.state["moves"]
-
-
-def inform_engine_of_update(engine, game):
-    if check_for_draw_offer(game):
-        engine.inform_draw()
 
 
 def tell_user_game_result(game, board):


### PR DESCRIPTION
The draw offer will be in the next gameState update when it is the
engine's turn to move. There's no need for the immediate notification.