### PR TITLE
Delete unneeded imports

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1,6 +1,5 @@
 import os
 import chess.engine
-import backoff
 import subprocess
 import logging
 from enum import Enum
@@ -8,7 +7,6 @@ from enum import Enum
 logger = logging.getLogger(__name__)
 
 
-@backoff.on_exception(backoff.expo, BaseException, max_time=120)
 def create_engine(config):
     cfg = config["engine"]
     engine_path = os.path.join(cfg["dir"], cfg["name"])

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -18,7 +18,6 @@ import sys
 import random
 import os
 import io
-import traceback
 import copy
 from config import load_config
 from conversation import Conversation, ChatLine


### PR DESCRIPTION
For the create_engine() function, I don't think there's any error that could occur that would be fixed by rerunning create_engine(). Besides, that backoff is redundant with the play_game() backoff.