### PR TITLE
Stop using online opening books after x out of book moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Besides the above, there are many possible options within `config.yml` for confi
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 - `online_moves`: This section gives your bot access to various online resources for choosing moves like opening books and endgame tablebases. This can be a supplement or a replacement for chess databases stored on your computer. There are three sections that correspond to three different online databases:
+    - `max_out_of_book_moves`: Stop using online opening books after they don't have a move for `max_out_of_book_moves` positions. Doesn't apply for the online endgame tablebases.
     1. `chessdb_book`: Consults a [Chinese chess position database](https://www.chessdb.cn/), which also hosts a xiangqi database.
     2. `lichess_cloud_analysis`: Consults [Lichess' own position analysis database](https://lichess.org/api#operation/apiCloudEval).
     3. `online_egtb`: Consults either the online Syzygy 7-piece endgame tablebase [hosted by Lichess](https://lichess.org/blog/W3WeMyQAACQAdfAL/7-piece-syzygy-tablebases-are-complete) or the chessdb listed above.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Besides the above, there are many possible options within `config.yml` for confi
     1. `chessdb_book`: Consults a [Chinese chess position database](https://www.chessdb.cn/), which also hosts a xiangqi database.
     2. `lichess_cloud_analysis`: Consults [Lichess' own position analysis database](https://lichess.org/api#operation/apiCloudEval).
     3. `online_egtb`: Consults either the online Syzygy 7-piece endgame tablebase [hosted by Lichess](https://lichess.org/blog/W3WeMyQAACQAdfAL/7-piece-syzygy-tablebases-are-complete) or the chessdb listed above.
-    - `max_out_of_book_moves`: Stop using online opening books after they don't have a move for `max_out_of_book_moves` positions. Doesn't apply for the online endgame tablebases.
+    - `max_out_of_book_moves`: Stop using online opening books after they don't have a move for `max_out_of_book_moves` positions. Doesn't apply to the online endgame tablebases.
     - Configurations common to all:
         - `enabled`: Whether to use the database at all.
         - `min_time`: The minimum time in seconds on the game clock necessary to allow the online database to be consulted.

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Besides the above, there are many possible options within `config.yml` for confi
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 - `online_moves`: This section gives your bot access to various online resources for choosing moves like opening books and endgame tablebases. This can be a supplement or a replacement for chess databases stored on your computer. There are three sections that correspond to three different online databases:
-    - `max_out_of_book_moves`: Stop using online opening books after they don't have a move for `max_out_of_book_moves` positions. Doesn't apply for the online endgame tablebases.
     1. `chessdb_book`: Consults a [Chinese chess position database](https://www.chessdb.cn/), which also hosts a xiangqi database.
     2. `lichess_cloud_analysis`: Consults [Lichess' own position analysis database](https://lichess.org/api#operation/apiCloudEval).
     3. `online_egtb`: Consults either the online Syzygy 7-piece endgame tablebase [hosted by Lichess](https://lichess.org/blog/W3WeMyQAACQAdfAL/7-piece-syzygy-tablebases-are-complete) or the chessdb listed above.
+    - `max_out_of_book_moves`: Stop using online opening books after they don't have a move for `max_out_of_book_moves` positions. Doesn't apply for the online endgame tablebases.
     - Configurations common to all:
         - `enabled`: Whether to use the database at all.
         - `min_time`: The minimum time in seconds on the game clock necessary to allow the online database to be consulted.

--- a/config.yml.default
+++ b/config.yml.default
@@ -32,7 +32,7 @@ engine:                      # Engine settings.
     offer_draw_moves: 5      # How many moves in a row the absolute value of the score has to be below the draw value.
     offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw.
   online_moves:
-    max_out_of_book_moves: 10 # Stop using online opening books after they don't have a move for 'max_out_of_book_moves' positions. Doesn't apply for the online endgame tablebases.
+    max_out_of_book_moves: 10 # Stop using online opening books after they don't have a move for 'max_out_of_book_moves' positions. Doesn't apply to the online endgame tablebases.
     chessdb_book:
       enabled: false
       min_time: 20

--- a/config.yml.default
+++ b/config.yml.default
@@ -32,6 +32,7 @@ engine:                      # Engine settings.
     offer_draw_moves: 5      # How many moves in a row the absolute value of the score has to be below the draw value.
     offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw.
   online_moves:
+    max_out_of_book_moves: 10 # Stop using online opening books after they don't have a move for 'max_out_of_book_moves' positions. Doesn't apply for the online endgame tablebases.
     chessdb_book:
       enabled: false
       min_time: 20

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -23,7 +23,7 @@ from config import load_config
 from conversation import Conversation, ChatLine
 from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError, ReadTimeout
 from rich.logging import RichHandler
-from collections import defaultdict
+from collections import defaultdict, Counter
 from http.client import RemoteDisconnected
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)
 __version__ = "1.2.0"
 
 terminated = False
+
+out_of_online_opening_book_moves = Counter()
 
 
 def signal_handler(signal, frame):
@@ -332,7 +334,6 @@ def play_game(li,
 
     first_move = True
     disconnect_time = 0
-    out_of_online_opening_book_moves = 0
     prior_game = None
     while not terminated:
         move_attempted = False
@@ -364,12 +365,11 @@ def play_game(li,
 
                     best_move = get_book_move(board, polyglot_cfg)
                     if best_move.move is None:
-                        best_move, out_of_online_opening_book_moves = get_online_move(li,
-                                                                                      board,
-                                                                                      game,
-                                                                                      online_moves_cfg,
-                                                                                      draw_or_resign_cfg,
-                                                                                      out_of_online_opening_book_moves)
+                        best_move = get_online_move(li,
+                                                    board,
+                                                    game,
+                                                    online_moves_cfg,
+                                                    draw_or_resign_cfg)
 
                     if best_move.move is None:
                         draw_offered = check_for_draw_offer(game)
@@ -696,7 +696,7 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
     return None, None
 
 
-def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg, out_of_online_opening_book_moves):
+def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
     online_egtb_cfg = online_moves_cfg.get("online_egtb", {})
     chessdb_cfg = online_moves_cfg.get("chessdb_book", {})
     lichess_cloud_cfg = online_moves_cfg.get("lichess_cloud_analysis", {})
@@ -714,21 +714,21 @@ def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg, out_o
         resign_on_egtb_loss = draw_or_resign_cfg.get("resign_for_egtb_minus_two", True)
         if can_resign and resign_on_egtb_loss and wdl == -2:
             resign = True
-    elif out_of_online_opening_book_moves < max_out_of_book_moves:
+    elif out_of_online_opening_book_moves[game.id] < max_out_of_book_moves:
         best_move = get_chessdb_move(li, board, game, chessdb_cfg)
 
-    if best_move is None and out_of_online_opening_book_moves < max_out_of_book_moves:
+    if best_move is None and out_of_online_opening_book_moves[game.id] < max_out_of_book_moves:
         best_move = get_lichess_cloud_move(li, board, game, lichess_cloud_cfg)
 
     if best_move:
         return chess.engine.PlayResult(chess.Move.from_uci(best_move),
                                        None,
                                        draw_offered=offer_draw,
-                                       resigned=resign), out_of_online_opening_book_moves
-    out_of_online_opening_book_moves += 1
-    if out_of_online_opening_book_moves == max_out_of_book_moves:
+                                       resigned=resign)
+    out_of_online_opening_book_moves[game.id] += 1
+    if out_of_online_opening_book_moves[game.id] == max_out_of_book_moves:
         logger.info("Will stop using online opening books.")
-    return chess.engine.PlayResult(None, None), out_of_online_opening_book_moves
+    return chess.engine.PlayResult(None, None)
 
 
 def choose_move(engine, board, game, ponder, draw_offered, start_time, move_overhead):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -32,6 +32,8 @@ __version__ = "1.2.0"
 
 terminated = False
 
+out_of_online_opening_book_moves = 0
+
 
 def signal_handler(signal, frame):
     global terminated
@@ -577,7 +579,7 @@ def get_lichess_cloud_move(li, board, game, lichess_cloud_cfg):
                         pvs = list(filter(lambda pv: pv["cp"] <= best_eval + max_difference, pvs))
                     pv = random.choice(pvs)
                 move = pv["moves"].split()[0]
-                score = pv["cp"]
+                score = pv["cp"] if wb == "w" else -pv["cp"]
                 logger.info(f"Got move {move} from lichess cloud analysis (depth: {depth}, score: {score}, knodes: {knodes})")
     except Exception:
         pass
@@ -655,6 +657,18 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
                 else:
                     return 2
 
+            def score_to_dtz(score):
+                if score < -20000:
+                    return -30000 - score
+                elif score < 0:
+                    return -20000 - score
+                elif score == 0:
+                    return 0
+                elif score <= 20000:
+                    return 20000 - score
+                else:
+                    return 30000 - score
+
             action = "querypv" if quality == "best" else "queryall"
             data = li.api_get("https://www.chessdb.cn/cdb.php",
                               params={"action": action, "board": board.fen(), "json": 1})
@@ -673,7 +687,8 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
                     move = random_move["uci"]
 
                 wdl = score_to_wdl(score)
-                logger.info(f"Got move {move} from chessdb.cn (wdl: {wdl})")
+                dtz = score_to_dtz(score)
+                logger.info(f"Got move {move} from chessdb.cn (wdl: {wdl}, dtz: {dtz})")
                 return move, score_to_wdl(score)
     except Exception:
         pass
@@ -682,15 +697,15 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
 
 
 def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
+    global out_of_online_opening_book_moves
     online_egtb_cfg = online_moves_cfg.get("online_egtb", {})
     chessdb_cfg = online_moves_cfg.get("chessdb_book", {})
     lichess_cloud_cfg = online_moves_cfg.get("lichess_cloud_analysis", {})
+    max_out_of_book_moves = online_moves_cfg.get("max_out_of_book_moves", 10)
     offer_draw = False
     resign = False
     best_move, wdl = get_online_egtb_move(li, board, game, online_egtb_cfg)
-    if best_move is None:
-        best_move = get_chessdb_move(li, board, game, chessdb_cfg)
-    else:
+    if best_move is not None:
         can_offer_draw = draw_or_resign_cfg.get("offer_draw_enabled", False)
         offer_draw_for_zero = draw_or_resign_cfg.get("offer_draw_for_egtb_zero", True)
         if can_offer_draw and offer_draw_for_zero and wdl == 0:
@@ -700,8 +715,10 @@ def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
         resign_on_egtb_loss = draw_or_resign_cfg.get("resign_for_egtb_minus_two", True)
         if can_resign and resign_on_egtb_loss and wdl == -2:
             resign = True
+    elif out_of_online_opening_book_moves < max_out_of_book_moves:
+        best_move = get_chessdb_move(li, board, game, chessdb_cfg)
 
-    if best_move is None:
+    if best_move is None and out_of_online_opening_book_moves < max_out_of_book_moves:
         best_move = get_lichess_cloud_move(li, board, game, lichess_cloud_cfg)
 
     if best_move:
@@ -709,6 +726,9 @@ def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
                                        None,
                                        draw_offered=offer_draw,
                                        resigned=resign)
+    out_of_online_opening_book_moves += 1
+    if out_of_online_opening_book_moves == max_out_of_book_moves:
+        logger.info("Will stop using online opening books.")
     return chess.engine.PlayResult(None, None)
 
 


### PR DESCRIPTION
After `max_out_of_book_moves` of the online opening books (chessdb, lichess cloud analysis) not having a move, we will stop using them, because they are unlikely to have a move for future positions and these move requests take a lot of time (especially for bullet).
Also, changed lichess cloud analysis to show the score from the perspective of the user and added dtz score to the chessdb egtb.