### PR TITLE
Use separate method for online chess DB access

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -520,7 +520,7 @@ def get_chessdb_move(li, board, game, chessdb_cfg):
         params = {"action": action[quality],
                   "board": board.fen(),
                   "json": 1}
-        data = li.api_get(site, params=params)
+        data = li.online_book_get(site, params=params)
         if data["status"] == "ok":
             if quality == "best":
                 depth = data["depth"]
@@ -534,7 +534,7 @@ def get_chessdb_move(li, board, game, chessdb_cfg):
 
         if chessdb_cfg.get("contribute", True):
             params["action"] = "queue"
-            li.api_get(site, params=params)
+            li.online_book_get(site, params=params)
     except Exception:
         pass
 
@@ -556,11 +556,10 @@ def get_lichess_cloud_move(li, board, game, lichess_cloud_cfg):
     variant = "standard" if board.uci_variant == "chess" else board.uci_variant
 
     try:
-        data = li.api_get("https://lichess.org/api/cloud-eval",
-                          params={"fen": board.fen(),
-                                  "multiPv": multipv,
-                                  "variant": variant},
-                          raise_for_status=False)
+        data = li.online_book_get("https://lichess.org/api/cloud-eval",
+                                  params={"fen": board.fen(),
+                                          "multiPv": multipv,
+                                          "variant": variant})
         if "error" not in data:
             depth = data["depth"]
             knodes = data["knodes"]
@@ -618,8 +617,8 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
                            "win": 2}
             max_pieces = 7 if board.uci_variant == "chess" else 6
             if pieces <= max_pieces:
-                data = li.api_get(f"http://tablebase.lichess.ovh/{variant}",
-                                  params={"fen": board.fen()})
+                data = li.online_book_get(f"http://tablebase.lichess.ovh/{variant}",
+                                          params={"fen": board.fen()})
                 if quality == "best":
                     move = data["moves"][0]["uci"]
                     wdl = name_to_wld[data["moves"][0]["category"]] * -1
@@ -670,8 +669,8 @@ def get_online_egtb_move(li, board, game, online_egtb_cfg):
                     return 30000 - score
 
             action = "querypv" if quality == "best" else "queryall"
-            data = li.api_get("https://www.chessdb.cn/cdb.php",
-                              params={"action": action, "board": board.fen(), "json": 1})
+            data = li.online_book_get("https://www.chessdb.cn/cdb.php",
+                                      params={"action": action, "board": board.fen(), "json": 1})
             if data["status"] == "ok":
                 if quality == "best":
                     score = data["score"]

--- a/lichess.py
+++ b/lichess.py
@@ -61,12 +61,12 @@ class Lichess:
                           giveup=is_final,
                           backoff_log_level=logging.DEBUG,
                           giveup_log_level=logging.DEBUG)
-    def api_get(self, path, raise_for_status=True, get_raw_text=False, params=None):
+    def api_get(self, path, get_raw_text=False):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        response = self.session.get(url, timeout=2, params=params)
-        if rate_limit_check(response) or raise_for_status:
-            response.raise_for_status()
+        response = self.session.get(url, timeout=2)
+        rate_limit_check(response)
+        response.raise_for_status()
         response.encoding = "utf-8"
         return response.text if get_raw_text else response.json()
 
@@ -136,9 +136,7 @@ class Lichess:
         self.session.headers.update(self.header)
 
     def get_game_pgn(self, game_id):
-        return self.api_get(ENDPOINTS["export"].format(game_id),
-                            get_raw_text=True,
-                            params={"literate": "true"})
+        return self.api_get(ENDPOINTS["export"].format(game_id), get_raw_text=True)
 
     def get_online_bots(self):
         online_bots = self.api_get(ENDPOINTS["online_bots"], get_raw_text=True)

--- a/lichess.py
+++ b/lichess.py
@@ -155,6 +155,4 @@ class Lichess:
                              raise_for_status=False)
 
     def online_book_get(self, path, params=None):
-        response = self.session.get(path, timeout=2, params=params)
-        response.raise_for_status()
-        return response.json()
+        return self.session.get(path, timeout=2, params=params).json()

--- a/lichess.py
+++ b/lichess.py
@@ -153,3 +153,8 @@ class Lichess:
     def cancel(self, challenge_id):
         return self.api_post(ENDPOINTS["cancel"].format(challenge_id),
                              raise_for_status=False)
+
+    def online_book_get(self, path, params=None):
+        response = self.session.get(path, timeout=2, params=params)
+        response.raise_for_status()
+        return response.json()


### PR DESCRIPTION
Since the api_get() method uses backup to retry communications, any
problems with communicating with the online chess databases can
result in retrying for up to a minute. This would waste time that bots
could use to pick their own moves.

This commit replaces the Lichess.api_get() method with another that
does not have backoff, so it does not retry requests.