### PR TITLE
Fix all remaining flake8 errors except for function too complex

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -5,7 +5,7 @@ engine:                      # Engine settings.
   dir: "./engines/"          # Directory containing the engine. This can be an absolute path or one relative to lichess-bot/.
   name: "engine_name"        # Binary name of the engine to use.
   working_dir: ""            # Directory where the chess engine will read and write files. If blank or missing, the current directory is used.
-  protocol: "uci"            # "uci" or "xboard"
+  protocol: "uci"            # "uci", "xboard" or "homemade"
   ponder: true               # Think on opponent's time.
   polyglot:
     enabled: false           # Activate polyglot book.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -893,9 +893,8 @@ def intro():
 def start_lichess_bot():
     parser = argparse.ArgumentParser(description="Play on Lichess with a bot")
     parser.add_argument("-u", action="store_true", help="Upgrade your account to a bot account.")
-    parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.org."
-                        )
-    parser.add_argument("--config", help="Specify a configuration file (defaults to ./config.yml)")
+    parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.")
+    parser.add_argument("--config", help="Specify a configuration file (defaults to ./config.yml).")
     parser.add_argument("-l", "--logfile", help="Record all console output to a log file.", default=None)
     args = parser.parse_args()
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -180,7 +180,8 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 logger.warning("Unable to handle response from lichess.org:")
                 logger.warning(event)
                 if event.get("error") == "Missing scope":
-                    logger.warning('Please check that the API access token for your bot has the scope "Play games with the bot API".')
+                    logger.warning('Please check that the API access token for your bot has the scope "Play games '
+                                   'with the bot API".')
                 continue
 
             if event["type"] == "terminated":
@@ -893,7 +894,8 @@ def intro():
 def start_lichess_bot():
     parser = argparse.ArgumentParser(description="Play on Lichess with a bot")
     parser.add_argument("-u", action="store_true", help="Upgrade your account to a bot account.")
-    parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.org.")
+    parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.org."
+                        )
     parser.add_argument("--config", help="Specify a configuration file (defaults to ./config.yml)")
     parser.add_argument("-l", "--logfile", help="Record all console output to a log file.", default=None)
     args = parser.parse_args()

--- a/strategies.py
+++ b/strategies.py
@@ -3,7 +3,6 @@ Some example strategies for people who want to create a custom, homemade bot.
 And some handy classes to extend
 """
 
-import chess
 from chess.engine import PlayResult
 import random
 from engine_wrapper import EngineWrapper

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -38,7 +38,8 @@ def download_sf():
 
 
 def download_lc0():
-    response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.28.2/lc0-v0.28.2-windows-cpu-dnnl.zip", allow_redirects=True)
+    response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.28.2/lc0-v0.28.2-windows-cpu-dnnl.zip",
+                            allow_redirects=True)
     with open("./TEMP/lc0_zip.zip", "wb") as file:
         file.write(response.content)
     with zipfile.ZipFile("./TEMP/lc0_zip.zip", "r") as zip_ref:
@@ -269,6 +270,7 @@ def test_homemade():
 class Stockfish(ExampleEngine):
     def __init__(self, commands, options, stderr, draw_or_resign, **popen_args):
         super().__init__(commands, options, stderr, draw_or_resign, **popen_args)
+        import chess
         self.engine = chess.engine.SimpleEngine.popen_uci('{stockfish_path}')
 
     def search(self, board, time_limit, *args):


### PR DESCRIPTION
- Breaks 3 lines
- Changes `lambda` to `def`
- Uses `getattr` instead of `eval`
- Removes `chess` from `startegies.py` and moves it inside `test_bot.py`

The `function too complex` errors can be fixed by simplifying the functions or by raising the threshold in `python-build.yml`.