### PR TITLE
Reset connection if bot is offline

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -121,7 +121,7 @@ def game_error_handler(error):
 def should_restart(li, username):
     online_bots = li.get_online_bots()
     bot = list(filter(lambda bot: bot["username"] == username, online_bots))
-    return bot and bot[0].get("online")
+    return not (bot and bot[0].get("online", True))
 
 
 def start(li, user_profile, config, logging_level, log_filename, one_game=False):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -277,8 +277,9 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 logger.info("Challenging a random bot")
                 matchmaker.challenge()
 
-            if time.time() > last_check_online_time + 300:
+            if time.time() > last_check_online_time + 10:
                 if should_restart(li, user_profile["username"]):
+                    logger.info("Will reset connection with lichess")
                     li.reset_connection()
                 last_check_online_time = time.time()
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -120,8 +120,8 @@ def game_error_handler(error):
 
 def should_restart(li, username):
     online_bots = li.get_online_bots()
-    bot = list(filter(lambda bot: bot["username"] == username, online_bots))[0]
-    return bot.get("online")
+    bot = list(filter(lambda bot: bot["username"] == username, online_bots))
+    return bot and bot[0].get("online")
 
 
 def start(li, user_profile, config, logging_level, log_filename, one_game=False):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -120,8 +120,8 @@ def game_error_handler(error):
 
 def should_restart(li, username):
     online_bots = li.get_online_bots()
-    is_bot_online = not list(filter(lambda bot: bot["username"] == username, online_bots))
-    return is_bot_online
+    is_bot_offline = not list(filter(lambda bot: bot["username"] == username, online_bots))
+    return is_bot_offline
 
 
 def start(li, user_profile, config, logging_level, log_filename, one_game=False):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -118,12 +118,6 @@ def game_error_handler(error):
     logger.exception("Game ended due to error:", exc_info=error)
 
 
-def should_restart(li, username):
-    online_bots = li.get_online_bots()
-    is_bot_offline = not list(filter(lambda bot: bot["username"] == username, online_bots))
-    return is_bot_offline
-
-
 def start(li, user_profile, config, logging_level, log_filename, one_game=False):
     challenge_config = config["challenge"]
     max_games = challenge_config.get("concurrency", 1)
@@ -278,7 +272,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 matchmaker.challenge()
 
             if time.time() > last_check_online_time + 60 * 60:  # 1 hour.
-                if should_restart(li, user_profile["username"]):
+                if not li.is_online(user_profile["id"]):
                     logger.info("Will reset connection with lichess")
                     li.reset_connection()
                 last_check_online_time = time.time()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -277,7 +277,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 logger.info("Challenging a random bot")
                 matchmaker.challenge()
 
-            if time.time() > last_check_online_time + 10:
+            if time.time() > last_check_online_time + 300:
                 if should_restart(li, user_profile["username"]):
                     logger.info("Will reset connection with lichess")
                     li.reset_connection()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -120,8 +120,8 @@ def game_error_handler(error):
 
 def should_restart(li, username):
     online_bots = li.get_online_bots()
-    bot = list(filter(lambda bot: bot["username"] == username, online_bots))
-    return not (bot and bot[0].get("online", True))
+    is_bot_online = not list(filter(lambda bot: bot["username"] == username, online_bots))
+    return is_bot_online
 
 
 def start(li, user_profile, config, logging_level, log_filename, one_game=False):
@@ -277,7 +277,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 logger.info("Challenging a random bot")
                 matchmaker.challenge()
 
-            if time.time() > last_check_online_time + 300:
+            if time.time() > last_check_online_time + 60 * 60:  # 1 hour.
                 if should_restart(li, user_profile["username"]):
                     logger.info("Will reset connection with lichess")
                     li.reset_connection()

--- a/lichess.py
+++ b/lichess.py
@@ -154,3 +154,8 @@ class Lichess:
 
     def online_book_get(self, path, params=None):
         return self.session.get(path, timeout=2, params=params).json()
+
+    def reset_connection(self):
+        self.session.close()
+        self.session = requests.Session()
+        self.session.headers.update(self.header)

--- a/lichess.py
+++ b/lichess.py
@@ -23,7 +23,8 @@ ENDPOINTS = {
     "export": "/game/export/{}",
     "online_bots": "/api/bot/online",
     "challenge": "/api/challenge/{}",
-    "cancel": "/api/challenge/{}/cancel"
+    "cancel": "/api/challenge/{}/cancel",
+    "status": "/api/users/status"
 }
 
 
@@ -61,10 +62,10 @@ class Lichess:
                           giveup=is_final,
                           backoff_log_level=logging.DEBUG,
                           giveup_log_level=logging.DEBUG)
-    def api_get(self, path, get_raw_text=False):
+    def api_get(self, path, params=None, get_raw_text=False):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        response = self.session.get(url, timeout=2)
+        response = self.session.get(url, params=params, timeout=2)
         rate_limit_check(response)
         response.raise_for_status()
         response.encoding = "utf-8"
@@ -154,6 +155,10 @@ class Lichess:
 
     def online_book_get(self, path, params=None):
         return self.session.get(path, timeout=2, params=params).json()
+
+    def is_online(self, user_id):
+        user = self.api_get(ENDPOINTS["status"], params={"ids": user_id})
+        return user and user[0].get("online")
 
     def reset_connection(self):
         self.session.close()

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -227,3 +227,6 @@ class Lichess:
 
 *
 """
+
+    def get_online_bots(self):
+        return [{"username": "b"}]

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -26,6 +26,14 @@ ENDPOINTS = {
 }
 
 
+def rate_limit_check(response):
+    if response.status_code == 429:
+        logger.warning("Rate limited. Waiting 1 minute until next request.")
+        time.sleep(60)
+        return True
+    return False
+
+
 class GameStream:
     def __init__(self):
         self.moves_sent = ""
@@ -139,22 +147,26 @@ class Lichess:
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)
-    def api_get(self, path, raise_for_status=True):
+    def api_get(self, path, get_raw_text=False):
+        logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
         response = self.session.get(url, timeout=2)
-        if raise_for_status:
-            response.raise_for_status()
-        return response.json()
+        rate_limit_check(response)
+        response.raise_for_status()
+        response.encoding = "utf-8"
+        return response.text if get_raw_text else response.json()
 
     @backoff.on_exception(backoff.constant,
                           (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                           max_time=60,
                           interval=0.1,
                           giveup=is_final)
-    def api_post(self, path, data=None, headers=None, params=None):
+    def api_post(self, path, data=None, headers=None, params=None, payload=None, raise_for_status=True):
+        logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        response = self.session.post(url, data=data, headers=headers, params=params, timeout=2)
-        response.raise_for_status()
+        response = self.session.post(url, data=data, headers=headers, params=params, json=payload, timeout=2)
+        if rate_limit_check(response) or raise_for_status:
+            response.raise_for_status()
         return response.json()
 
     def get_game(self, game_id):
@@ -229,4 +241,16 @@ class Lichess:
 """
 
     def get_online_bots(self):
-        return [{"username": "b"}]
+        return [{"username": "b", "online": True}]
+
+    def challenge(self, username, params):
+        return
+
+    def cancel(self, challenge_id):
+        return
+
+    def online_book_get(self, path, params=None):
+        return self.session.get(path, timeout=2, params=params).json()
+
+    def reset_connection(self):
+        return


### PR DESCRIPTION
Idea taken from https://github.com/ShailChoksi/lichess-bot/issues/222#issuecomment-1201663501.
Attempts to fix #135 and #222.
Checks every 5 minutes if the bot is offline and resets the connection. While matchmaking may be resetting the connection (https://github.com/ShailChoksi/lichess-bot/issues/222#issuecomment-1201088500), not all bots have matchmaking enabled.