### PR TITLE
Only challenge bots with previous games of this type

### DIFF
--- a/matchmaking.py
+++ b/matchmaking.py
@@ -87,10 +87,10 @@ class Matchmaking:
 
         def is_suitable_opponent(bot):
             perf = bot["perfs"].get(game_type, {})
-            return (bot["username"] != self.username and
-                not bot.get("disabled") and
-                perf.get("games", 0) > 0 and
-                min_rating <= perf.get("rating", 0) <= max_rating)
+            return (bot["username"] != self.username
+                    and not bot.get("disabled")
+                    and perf.get("games", 0) > 0
+                    and min_rating <= perf.get("rating", 0) <= max_rating)
 
         online_bots = self.li.get_online_bots()
         online_bots = list(filter(is_suitable_opponent, online_bots))

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -85,12 +85,16 @@ class Matchmaking:
         min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 600
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
 
+        def is_suitable_opponent(bot):
+            perf = bot["perfs"].get(game_type, {})
+            return (bot["username"] != self.username and
+                not bot.get("disabled") and
+                perf.get("games", 0) > 0 and
+                min_rating <= perf.get("rating", 0) <= max_rating)
+
         online_bots = self.li.get_online_bots()
-        online_bots = list(filter(lambda bot: bot["username"] != self.username and
-                                  not bot.get("disabled") and
-                                  bot["perfs"].get(game_type, {}).get("games", 0) > 0 and
-                                  min_rating <= bot["perfs"].get(game_type, {}).get("rating", 0) <= max_rating,
-                                  online_bots))
+        online_bots = list(filter(is_suitable_opponent, online_bots))
+
         bot_username = random.choice(online_bots)["username"] if online_bots else None
         return bot_username, base_time, increment, days, variant
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -86,8 +86,10 @@ class Matchmaking:
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
 
         online_bots = self.li.get_online_bots()
-        online_bots = list(filter(lambda bot: bot["username"] != self.username and not bot.get("disabled") and
-                                  min_rating <= ((bot["perfs"].get(game_type) or {}).get("rating") or 0) <= max_rating,
+        online_bots = list(filter(lambda bot: bot["username"] != self.username and
+                                  not bot.get("disabled") and
+                                  bot["perfs"].get(game_type, {}).get("games", 0) > 0 and
+                                  min_rating <= bot["perfs"].get(game_type, {}).get("rating", 0) <= max_rating,
                                   online_bots))
         bot_username = random.choice(online_bots)["username"] if online_bots else None
         return bot_username, base_time, increment, days, variant


### PR DESCRIPTION
The first PR coming out of #494.

This behaviour was already intended, to avoid making challenges that are very likely to be declined. But as suspected, the API returns bots with 0 games and a provisional rating of 1500 or 2000.

One question: The lambda keeps getting bigger and I'm planning to add another check for terms of service violation soon. Should I extract it into a local definition for readability?

```python
        def is_suitable_opponent(bot):
            perf = bot["perfs"].get(game_type, {})
            return (bot["username"] != self.username and
                not bot.get("disabled") and
                perf.get("games", 0) > 0 and
                min_rating <= perf.get("rating", 0) <= max_rating)

        online_bots = self.li.get_online_bots()
        online_bots = list(filter(is_suitable_opponent, online_bots))
```