### PR TITLE
Fix config.yml.default comment on book max_depth

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -20,7 +20,7 @@ engine:                      # Engine settings.
 #     Use the same pattern for 'giveaway' (antichess), 'crazyhouse', 'horde', 'kingofthehill', 'racingkings' and '3check' as well.
     min_weight: 1            # Does not select moves with weight below min_weight (min 0, max: 65535).
     selection: "weighted_random" # Move selection is one of "weighted_random", "uniform_random" or "best_move" (but not below the min_weight in the 2nd and 3rd case).
-    max_depth: 8             # Half move max depth.
+    max_depth: 8             # How many moves from the start to take from the book.
   draw_or_resign:
     resign_enabled: false
     resign_score: -1000      # If the score is less than or equal to this value, the bot resigns (in cp).


### PR DESCRIPTION
Just a super small thing, but this got me confused when I started using lichess-bot (I set it to twice of what I should have).

The documentation in the README is already correct.