### PR TITLE
Add config flag to allow/forbid challenging ToS violators

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `challenge_days`: A list of number of days for a correspondence challenge (to be chosen at random).
   - `opponent_min_rating`: The minimum rating of the opponent bot. The minimum rating in lichess is 600.
   - `opponent_max_rating`: The maximum rating of the opponent bot. The maximum rating in lichess is 4000.
+  - `opponent_allow_tos_violation`: Whether to challenge bots that violated Lichess Terms of Service. Note that even rated games against them will not affect ratings.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
 
 If there are entries for both real-time (`challenge_initial_time` and/or `challenge_increment`) and correspondence games (`challenge_days`), the challenge will be a random choice between the two.
@@ -265,6 +266,7 @@ matchmaking:
      - 2
   opponent_min_rating: 600
   opponent_max_rating: 4000
+  opponent_allow_tos_violation: true
   challenge_mode: "random"
 ```
 

--- a/config.yml.default
+++ b/config.yml.default
@@ -145,4 +145,5 @@ matchmaking:
 #    - 2
   opponent_min_rating: 600    # Opponents rating should be above this value (600 is the minimum rating in lichess).
   opponent_max_rating: 4000   # Opponents rating should be below this value (4000 is the maximum rating in lichess).
+  opponent_allow_tos_violation: true # Set to 'false' to prevent challenging bots that violated Lichess Terms of Service.
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -92,11 +92,13 @@ class Matchmaking:
 
         min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 600
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
+        allow_tos_violation = self.matchmaking_cfg.get("opponent_allow_tos_violation", True)
 
         def is_suitable_opponent(bot):
             perf = bot["perfs"].get(game_type, {})
             return (bot["username"] != self.username
                     and not bot.get("disabled")
+                    and (allow_tos_violation or not bot.get("tosViolation")) # Terms of Service
                     and perf.get("games", 0) > 0
                     and min_rating <= perf.get("rating", 0) <= max_rating)
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -98,7 +98,7 @@ class Matchmaking:
             perf = bot["perfs"].get(game_type, {})
             return (bot["username"] != self.username
                     and not bot.get("disabled")
-                    and (allow_tos_violation or not bot.get("tosViolation")) # Terms of Service
+                    and (allow_tos_violation or not bot.get("tosViolation"))  # Terms of Service
                     and perf.get("games", 0) > 0
                     and min_rating <= perf.get("rating", 0) <= max_rating)
 


### PR DESCRIPTION
Next one! By default, the behaviour stays the same, but I found the option useful to avoid playing rated games that in reality can't affect the rating.