### PR TITLE
Probe syzygy and gaviota TBs from the computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,20 @@ Besides the above, there are many possible options within `config.yml` for confi
         - `max_score_difference`: When `move_quality` is set to `"good"`, this option specifies the maximum difference between the top scoring move and any other move that will make up the set from which a move will be chosen randomly. If this option is set to 25 and the top move in a position has a score of 100, no move with a score of less than 75 will be returned.
         - `min_knodes`: The minimum number of kilonodes to search. The minimum number of nodes to search is this value times 1000.
     - Configurations only in `online_egtb`:
-        -  `max_pieces`: The maximum number of pieces in the current board for which the tablebase will be consulted.
+        - `max_pieces`: The maximum number of pieces in the current board for which the tablebase will be consulted.
         - `source`: One of `chessdb` or `lichess`. Lichess also has tablebases for atomic and antichess while chessdb only has those for standard.
+- `lichess_bot_tbs`: This section gives your bot access to various resources for choosing moves like syzygy and gaviota endgame tablebases. There are two sections that correspond to two different endgame tablebases:
+    1. `syzygy`: Get moves from syzygy tablebases. `.*tbw` have to be always provided. Syzygy TBs are generally smaller that gaviota TBs.
+    2. `gaviota`: Get moves from gaviota tablebases.
+    - Configurations common to all:
+        - `enabled`: Whether to use the tablebases at all.
+        - `paths`: The paths to the tablebases.
+        - `max_pieces`: The maximum number of pieces in the current board for which the tablebase will be consulted.
+        - `move_quality`: Choice of `"good"`, or `"best"`.
+            - `best`: Choose only the highest scoring move. When using `syzygy`, if `.*tbz` files are not provided, the bot will attempt to get a move using `move_quality` = `good`.
+            - `good`: Choose randomly from the top moves.
+    - Configurations only in `gaviota`:
+        - `min_dtm_to_consider_as_wdl_1`: The minimum DTM to consider as syzygy WDL=1/-1. Setting it to 100 will disable it.
 - `engine_options`: Command line options to pass to the engine on startup. For example, the `config.yml.default` has the configuration
 ```yml
   engine_options:

--- a/config.yml.default
+++ b/config.yml.default
@@ -52,6 +52,20 @@ engine:                      # Engine settings.
       max_pieces: 7
       source: "lichess"      # One of "lichess", "chessdb".
       move_quality: "best"   # One of "good", "best".
+  lichess_bot_tbs:
+    syzygy:
+      enabled: false
+      paths:
+        - "engines/syzygy"
+      max_pieces: 7
+      move_quality: "best"   # One of "good", "best".
+    gaviota:
+      enabled: false
+      paths:
+        - "engines/gaviota"
+      max_pieces: 5
+      min_dtm_to_consider_as_wdl_1: 120  # The minimum dtm to consider as syzygy wdl=1/-1. Set to 100 to disable.
+      move_quality: "best"   # One of "good", "best".
 # engine_options:            # Any custom command line params to pass to the engine.
 #   cpuct: 3.1
   homemade_options:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -378,6 +378,12 @@ def play_game(li,
                     print_move_number(board)
 
                     best_move = get_book_move(board, polyglot_cfg)
+                    
+                    if best_move.move is None:
+                        best_move = get_egtb_move(board,
+                                                  lichess_bot_tbs,
+                                                  draw_or_resign_cfg)
+                    
                     if best_move.move is None:
                         best_move = get_online_move(li,
                                                     board,
@@ -385,10 +391,6 @@ def play_game(li,
                                                     online_moves_cfg,
                                                     draw_or_resign_cfg)
 
-                    if best_move.move is None:
-                        best_move = get_egtb_move(board,
-                                                  lichess_bot_tbs,
-                                                  draw_or_resign_cfg)
 
                     if best_move.move is None:
                         draw_offered = check_for_draw_offer(game)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -391,7 +391,6 @@ def play_game(li,
                                                     online_moves_cfg,
                                                     draw_or_resign_cfg)
 
-
                     if best_move.move is None:
                         draw_offered = check_for_draw_offer(game)
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -378,12 +378,12 @@ def play_game(li,
                     print_move_number(board)
 
                     best_move = get_book_move(board, polyglot_cfg)
-                    
+
                     if best_move.move is None:
                         best_move = get_egtb_move(board,
                                                   lichess_bot_tbs,
                                                   draw_or_resign_cfg)
-                    
+
                     if best_move.move is None:
                         best_move = get_online_move(li,
                                                     board,

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -822,10 +822,10 @@ def get_gaviota(board, gaviota_cfg):
     move_quality = gaviota_cfg.get("move_quality", "best")
     # Since gaviota TBs use dtm and not dtz, we have to put a limit where after it the position are considered to have
     # a syzygy wdl=1/-1, so the positions are draws under the 50 move rule. We use min_dtm_to_consider_as_wdl_1 as a
-    # second limit, because if a position has 5 pieces it may take 98 half-moves, to go down to 4 pieces and another 12
-    # to mate, so this position has a syzygy wdl=2/-2. To be safe, the first limit is 100 moves, which guarantees that
-    # all moves have a syzygy wdl=2/-2. Setting min_dtm_to_consider_as_wdl_1 to 100 will disable it because dtm >= dtz,
-    # so if abs(dtm) < 100 => abs(dtz) < 100, so wdl=2/-2.
+    # second limit, because if a position has 5 pieces and dtm=110 it may take 98 half-moves, to go down to 4 pieces and
+    # another 12 to mate, so this position has a syzygy wdl=2/-2. To be safe, the first limit is 100 moves, which
+    # guarantees that all moves have a syzygy wdl=2/-2. Setting min_dtm_to_consider_as_wdl_1 to 100 will disable it
+    # because dtm >= dtz, so if abs(dtm) < 100 => abs(dtz) < 100, so wdl=2/-2.
     min_dtm_to_consider_as_wdl_1 = gaviota_cfg.get("min_dtm_to_consider_as_wdl_1", 120)
     with chess.gaviota.open_tablebase(gaviota_cfg["paths"][0]) as tablebase:
         for path in gaviota_cfg["paths"][1:]:
@@ -872,7 +872,7 @@ def get_gaviota(board, gaviota_cfg):
                     # want to avoid these positions, if there is a move where even when we add the halfmove_clock the
                     # dtz is still <100.
                     best_moves = [(move, dtm) for move, dtm in good_moves if dtm < 100]
-                if best_dtm < min_dtm_to_consider_as_wdl_1:
+                elif best_dtm < min_dtm_to_consider_as_wdl_1:
                     # If a move had wdl=2 and dtz=98, but halfmove_clock is 4 then the real wdl=1 and dtz=102, so we
                     # want to avoid these positions, if there is a move where even when we add the halfmove_clock the
                     # dtz is still <100.
@@ -885,6 +885,8 @@ def get_gaviota(board, gaviota_cfg):
                     # If a move had wdl=-2 and dtz=-98, but halfmove_clock is 4 then the real wdl=-1 and dtz=-102, so we
                     # want to only choose between the moves where the real wdl=-1.
                     best_moves = [(move, dtm) for move, dtm in good_moves if dtm <= -100]
+                else:
+                    best_moves = good_moves
             else:
                 # There can be multiple moves with the same dtm.
                 best_moves = [(move, dtm) for move, dtm in good_moves if dtm == best_dtm]

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -1,6 +1,8 @@
 import argparse
 import chess
 import chess.pgn
+import chess.syzygy
+import chess.gaviota
 from chess.variant import find_variant
 import chess.polyglot
 import engine_wrapper
@@ -331,6 +333,7 @@ def play_game(li,
     polyglot_cfg = engine_cfg.get("polyglot", {})
     online_moves_cfg = engine_cfg.get("online_moves", {})
     draw_or_resign_cfg = engine_cfg.get("draw_or_resign") or {}
+    lichess_bot_tbs = engine_cfg.get("lichess_bot_tbs") or {}
 
     greeting_cfg = config.get("greeting") or {}
     keyword_map = defaultdict(str, me=game.me.name, opponent=game.opponent.name)
@@ -381,6 +384,11 @@ def play_game(li,
                                                     game,
                                                     online_moves_cfg,
                                                     draw_or_resign_cfg)
+
+                    if best_move.move is None:
+                        best_move = get_egtb_move(board,
+                                                  lichess_bot_tbs,
+                                                  draw_or_resign_cfg)
 
                     if best_move.move is None:
                         draw_offered = check_for_draw_offer(game)
@@ -740,6 +748,164 @@ def get_online_move(li, board, game, online_moves_cfg, draw_or_resign_cfg):
     used_opening_books = chessdb_cfg.get("enabled") or lichess_cloud_cfg.get("enabled")
     if out_of_online_opening_book_moves[game.id] == max_out_of_book_moves and used_opening_books:
         logger.info("Will stop using online opening books.")
+    return chess.engine.PlayResult(None, None)
+
+
+def get_syzygy(board, syzygy_cfg):
+    if (not syzygy_cfg.get("enabled", False)
+            or chess.popcount(board.occupied) > syzygy_cfg.get("max_pieces", 7)
+            or board.uci_variant not in ["chess", "antichess", "atomic"]):
+        return None, None
+    move_quality = syzygy_cfg.get("move_quality", "best")
+    with chess.syzygy.open_tablebase(syzygy_cfg["paths"][0]) as tablebase:
+        for path in syzygy_cfg["paths"][1:]:
+            tablebase.add_directory(path)
+
+        try:
+            moves = {}
+            for move in board.legal_moves:
+                board_copy = board.copy()
+                board_copy.push(move)
+                dtz = -tablebase.probe_dtz(board_copy)
+                moves[move] = dtz + (1 if dtz > 0 else -1) * board_copy.halfmove_clock
+
+            def dtz_to_wdl(dtz):
+                if dtz <= -100:
+                    return -1
+                elif dtz < 0:
+                    return -2
+                elif dtz == 0:
+                    return 0
+                elif dtz < 100:
+                    return 2
+                else:
+                    return 1
+
+            best_wdl = max(map(dtz_to_wdl, moves.values()))
+            good_moves = [(move, dtz) for move, dtz in moves.items() if dtz_to_wdl(dtz) == best_wdl]
+            if move_quality == "good":
+                move, dtz = random.choice(good_moves)
+                logger.info(f"Got move {move.uci()} from syzygy (wdl: {best_wdl}, dtz: {dtz})")
+                return move, best_wdl
+            else:
+                best_dtz = min([dtz for move, dtz in good_moves])
+                best_moves = [move for move, dtz in good_moves if dtz == best_dtz]
+                move = random.choice(best_moves)
+                logger.info(f"Got move {move.uci()} from syzygy (wdl: {best_wdl}, dtz: {best_dtz})")
+                return move, best_wdl
+        except KeyError:
+            # Attempt to only get the WDL score. It returns a move of quality="good", even if quality is set to "best".
+            try:
+                moves = {}
+                for move in board.legal_moves:
+                    board_copy = board.copy()
+                    board_copy.push(move)
+                    moves[move] = -tablebase.probe_wdl(board_copy)
+                best_wdl = max(moves.values())
+                good_moves = [move for move, wdl in moves.items() if wdl == best_wdl]
+                move = random.choice(good_moves)
+                if move_quality == "best":
+                    logger.debug("Found a move using 'move_quality'='good'. We didn't find an '.rtbz' file for this endgame.")
+                logger.info(f"Got move {move.uci()} from syzygy (wdl: {best_wdl})")
+                return move, best_wdl
+            except KeyError:
+                return None, None
+
+
+def get_gaviota(board, gaviota_cfg):
+    if (not gaviota_cfg.get("enabled", False)
+            or chess.popcount(board.occupied) > gaviota_cfg.get("max_pieces", 5)
+            or board.uci_variant != "chess"):
+        return None, None
+    move_quality = gaviota_cfg.get("move_quality", "best")
+    # Since gaviota TBs use dtm and not dtz, we have to put a limit where after it the position are considered to have
+    # a syzygy wdl=1/-1, so the positions are draws under the 50 move rule. We use min_dtm_to_consider_as_wdl_1 as a
+    # second limit, because if a position has 5 pieces it may take 98 half-moves, to go down to 4 pieces and another 12
+    # to mate, so this position has a syzygy wdl=2/-2. To be safe, the first limit is 100 moves, which guarantees that
+    # all moves have a syzygy wdl=2/-2. Setting min_dtm_to_consider_as_wdl_1 to 100 will disable it because dtm >= dtz,
+    # so if abs(dtm) < 100 => abs(dtz) < 100, so wdl=2/-2.
+    min_dtm_to_consider_as_wdl_1 = gaviota_cfg.get("min_dtm_to_consider_as_wdl_1", 120)
+    with chess.gaviota.open_tablebase(gaviota_cfg["paths"][0]) as tablebase:
+        for path in gaviota_cfg["paths"][1:]:
+            tablebase.add_directory(path)
+
+        try:
+            moves = {}
+            for move in board.legal_moves:
+                board_copy = board.copy()
+                board_copy.push(move)
+                dtm = -tablebase.probe_dtm(board_copy)
+                moves[move] = dtm + (1 if dtm > 0 else -1) * board_copy.halfmove_clock
+
+            def dtm_to_gaviota_wdl(dtm):
+                if dtm < 0:
+                    return -1
+                elif dtm == 0:
+                    return 0
+                else:
+                    return 1
+
+            best_wdl = max(map(dtm_to_gaviota_wdl, moves.values()))
+            good_moves = [(move, dtm) for move, dtm in moves.items() if dtm_to_gaviota_wdl(dtm) == best_wdl]
+            best_dtm = min([dtm for move, dtm in good_moves])
+
+            def dtm_to_wdl(dtm):
+                if dtm <= -100:
+                    # We use 100 and not min_dtm_to_consider_as_wdl_1, because we want to play it safe and not resign in a
+                    # position where dtz=-102 (only if resign_for_egtb_minus_two is enabled).
+                    return -1
+                elif dtm < 0:
+                    return -2
+                elif dtm == 0:
+                    return 0
+                elif dtm < min_dtm_to_consider_as_wdl_1:
+                    return 2
+                else:
+                    return 1
+
+            pseudo_wdl = dtm_to_wdl(best_dtm)
+            if move_quality == "good":
+                if best_dtm < 100:
+                    # If a move had wdl=2 and dtz=98, but halfmove_clock is 4 then the real wdl=1 and dtz=102, so we
+                    # want to avoid these positions, if there is a move where even when we add the halfmove_clock the
+                    # dtz is still <100.
+                    best_moves = [(move, dtm) for move, dtm in good_moves if dtm < 100]
+                if best_dtm < min_dtm_to_consider_as_wdl_1:
+                    # If a move had wdl=2 and dtz=98, but halfmove_clock is 4 then the real wdl=1 and dtz=102, so we
+                    # want to avoid these positions, if there is a move where even when we add the halfmove_clock the
+                    # dtz is still <100.
+                    best_moves = [(move, dtm) for move, dtm in good_moves if dtm < min_dtm_to_consider_as_wdl_1]
+                elif best_dtm <= -min_dtm_to_consider_as_wdl_1:
+                    # If a move had wdl=-2 and dtz=-98, but halfmove_clock is 4 then the real wdl=-1 and dtz=-102, so we
+                    # want to only choose between the moves where the real wdl=-1.
+                    best_moves = [(move, dtm) for move, dtm in good_moves if dtm <= -min_dtm_to_consider_as_wdl_1]
+                elif best_dtm <= -100:
+                    # If a move had wdl=-2 and dtz=-98, but halfmove_clock is 4 then the real wdl=-1 and dtz=-102, so we
+                    # want to only choose between the moves where the real wdl=-1.
+                    best_moves = [(move, dtm) for move, dtm in good_moves if dtm <= -100]
+            else:
+                # There can be multiple moves with the same dtm.
+                best_moves = [(move, dtm) for move, dtm in good_moves if dtm == best_dtm]
+            move, dtm = random.choice(best_moves)
+            logger.info(f"Got move {move.uci()} from gaviota (pseudo wdl: {pseudo_wdl}, dtm: {dtm})")
+            return move, pseudo_wdl
+        except KeyError:
+            return None, None
+
+
+def get_egtb_move(board, lichess_bot_tbs, draw_or_resign_cfg):
+    best_move, wdl = get_syzygy(board, lichess_bot_tbs.get("syzygy") or {})
+    if best_move is None:
+        best_move, wdl = get_gaviota(board, lichess_bot_tbs.get("gaviota") or {})
+    if best_move:
+        can_offer_draw = draw_or_resign_cfg.get("offer_draw_enabled", False)
+        offer_draw_for_zero = draw_or_resign_cfg.get("offer_draw_for_egtb_zero", True)
+        offer_draw = bool(can_offer_draw and offer_draw_for_zero and wdl == 0)
+
+        can_resign = draw_or_resign_cfg.get("resign_enabled", False)
+        resign_on_egtb_loss = draw_or_resign_cfg.get("resign_for_egtb_minus_two", True)
+        resign = bool(can_resign and resign_on_egtb_loss and wdl == -2)
+        return chess.engine.PlayResult(best_move, None, draw_offered=offer_draw, resigned=resign)
     return chess.engine.PlayResult(None, None)
 
 


### PR DESCRIPTION
It uses python-chess to probe syzygy and gaviota TBs.

The part with the halfmove_clock can be tested by putting the code below before `start`:
```python
board = chess.Board(fen='2N5/8/6b1/8/8/2k5/K1n5/8 b - - 4 3')
print(get_syzygy(board, CONFIG["engine"]["lichess_bot_tbs"]["syzygy"]))
print(get_gaviota(board, CONFIG["engine"]["lichess_bot_tbs"]["gaviota"]))
print(get_egtb_move(board, CONFIG["engine"]["lichess_bot_tbs"], CONFIG["engine"]["draw_or_resign"]))
board = chess.Board(fen='2N5/8/6b1/8/8/2k5/K1n5/8 b - - 0 1')
print(get_syzygy(board, CONFIG["engine"]["lichess_bot_tbs"]["syzygy"]))
print(get_gaviota(board, CONFIG["engine"]["lichess_bot_tbs"]["gaviota"]))
print(get_egtb_move(board, CONFIG["engine"]["lichess_bot_tbs"], CONFIG["engine"]["draw_or_resign"]))
```

closes #314