### PR TITLE
Filter matchmaking based on relative ratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ matchmaking:
      - 2
 # opponent_min_rating: 600
 # opponent_max_rating: 4000
-  opponent_rating_difference: 500
+  opponent_rating_difference: 100
   opponent_allow_tos_violation: true
   challenge_mode: "random"
 ```

--- a/README.md
+++ b/README.md
@@ -245,10 +245,13 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `challenge_days`: A list of number of days for a correspondence challenge (to be chosen at random).
   - `opponent_min_rating`: The minimum rating of the opponent bot. The minimum rating in lichess is 600.
   - `opponent_max_rating`: The maximum rating of the opponent bot. The maximum rating in lichess is 4000.
+  - `opponent_rating_difference`: The maximum difference between the bot's rating and the opponent bot's rating.
   - `opponent_allow_tos_violation`: Whether to challenge bots that violated Lichess Terms of Service. Note that even rated games against them will not affect ratings.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
 
 If there are entries for both real-time (`challenge_initial_time` and/or `challenge_increment`) and correspondence games (`challenge_days`), the challenge will be a random choice between the two.
+
+If there are entries for both absolute ratings (`opponent_min_rating` and `opponent_max_rating`) and rating difference (`opponent_rating_difference`), the rating difference takes precendence.
 
 ```yml
 matchmaking:
@@ -264,8 +267,9 @@ matchmaking:
   challenge_days: 
      - 1
      - 2
-  opponent_min_rating: 600
-  opponent_max_rating: 4000
+# opponent_min_rating: 600
+# opponent_max_rating: 4000
+  opponent_rating_difference: 500
   opponent_allow_tos_violation: true
   challenge_mode: "random"
 ```

--- a/config.yml.default
+++ b/config.yml.default
@@ -143,7 +143,8 @@ matchmaking:
 #  challenge_days:            # Days for correspondence challenge (to be chosen at random).
 #    - 1
 #    - 2
-  opponent_min_rating: 600    # Opponents rating should be above this value (600 is the minimum rating in lichess).
-  opponent_max_rating: 4000   # Opponents rating should be below this value (4000 is the maximum rating in lichess).
+# opponent_min_rating: 600    # Opponents rating should be above this value (600 is the minimum rating in lichess).
+# opponent_max_rating: 4000   # Opponents rating should be below this value (4000 is the maximum rating in lichess).
+  opponent_rating_difference: 500 # The maximum difference in rating between the bot's rating and opponent's rating.
   opponent_allow_tos_violation: true # Set to 'false' to prevent challenging bots that violated Lichess Terms of Service.
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.

--- a/config.yml.default
+++ b/config.yml.default
@@ -145,6 +145,6 @@ matchmaking:
 #    - 2
 # opponent_min_rating: 600    # Opponents rating should be above this value (600 is the minimum rating in lichess).
 # opponent_max_rating: 4000   # Opponents rating should be below this value (4000 is the maximum rating in lichess).
-  opponent_rating_difference: 500 # The maximum difference in rating between the bot's rating and opponent's rating.
+  opponent_rating_difference: 100 # The maximum difference in rating between the bot's rating and opponent's rating.
   opponent_allow_tos_violation: true # Set to 'false' to prevent challenging bots that violated Lichess Terms of Service.
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -140,7 +140,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                                     if game["perf"] == "correspondence"]
     wait_for_correspondence_ping = False
     last_check_online_time = time.time()
-    matchmaker = matchmaking.Matchmaking(li, config, user_profile["username"])
+    matchmaker = matchmaking.Matchmaking(li, config, user_profile)
 
     busy_processes = 0
     queued_processes = 0

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -6,11 +6,12 @@ logger = logging.getLogger(__name__)
 
 
 class Matchmaking:
-    def __init__(self, li, config, username):
+    def __init__(self, li, config, user_profile):
         self.li = li
         self.variants = list(filter(lambda variant: variant != "fromPosition", config["challenge"]["variants"]))
         self.matchmaking_cfg = config.get("matchmaking") or {}
-        self.username = username
+        self.username = user_profile["username"]
+        self.perf = user_profile["perfs"]
         self.last_challenge_created = time.time()
         self.last_game_ended = time.time()
         self.challenge_expire_time = 25  # The challenge expires 20 seconds after creating it.
@@ -92,6 +93,11 @@ class Matchmaking:
 
         min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 600
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
+        rating_diff = self.matchmaking_cfg.get("opponent_rating_difference")
+        if rating_diff is not None:
+            bot_rating = self.perf.get(game_type, {}).get("rating", 0)
+            min_rating = bot_rating - rating_diff
+            max_rating = bot_rating + rating_diff
         allow_tos_violation = self.matchmaking_cfg.get("opponent_allow_tos_violation", True)
 
         def is_suitable_opponent(bot):

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -10,8 +10,9 @@ class Matchmaking:
         self.li = li
         self.variants = list(filter(lambda variant: variant != "fromPosition", config["challenge"]["variants"]))
         self.matchmaking_cfg = config.get("matchmaking") or {}
-        self.username = user_profile["username"]
-        self.perf = user_profile["perfs"]
+        self.user_profile = user_profile
+        self.user_profile_update_interval = 5 * 60  # 5 minutes
+        self.last_user_profile_update = time.time()
         self.last_challenge_created = time.time()
         self.last_game_ended = time.time()
         self.challenge_expire_time = 25  # The challenge expires 20 seconds after creating it.
@@ -68,6 +69,17 @@ class Matchmaking:
             match_time = [match_time]
         return random.choice(match_time)
 
+    def perf(self):
+        return self.user_profile["perfs"]
+
+    def username(self):
+        return self.user_profile["username"]
+
+    def update_user_profile(self):
+        if time.time() > self.last_user_profile_update + self.user_profile_update_interval:
+            self.last_user_profile_update = time.time()
+            self.user_profile = self.li.get_profile()
+
     def choose_opponent(self):
         variant = self.matchmaking_cfg.get("challenge_variant") or "random"
         if variant == "random":
@@ -95,14 +107,15 @@ class Matchmaking:
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
         rating_diff = self.matchmaking_cfg.get("opponent_rating_difference")
         if rating_diff is not None:
-            bot_rating = self.perf.get(game_type, {}).get("rating", 0)
+            bot_rating = self.perf().get(game_type, {}).get("rating", 0)
             min_rating = bot_rating - rating_diff
             max_rating = bot_rating + rating_diff
+        logger.info(f"Seeking {game_type} game with opponent rating in [{min_rating}, {max_rating}] ...")
         allow_tos_violation = self.matchmaking_cfg.get("opponent_allow_tos_violation", True)
 
         def is_suitable_opponent(bot):
             perf = bot["perfs"].get(game_type, {})
-            return (bot["username"] != self.username
+            return (bot["username"] != self.username()
                     and not bot.get("disabled")
                     and (allow_tos_violation or not bot.get("tosViolation"))  # Terms of Service
                     and perf.get("games", 0) > 0
@@ -115,6 +128,7 @@ class Matchmaking:
         return bot_username, base_time, increment, days, variant
 
     def challenge(self):
+        self.update_user_profile()
         bot_username, base_time, increment, days, variant = self.choose_opponent()
         logger.info(f"Will challenge {bot_username} for a {variant} game.")
         challenge_id = self.create_challenge(bot_username, base_time, increment, days, variant) if bot_username else None

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -213,7 +213,8 @@ class Lichess:
                    "followable": True,
                    "following": False,
                    "blocking": False,
-                   "followsYou": False}
+                   "followsYou": False,
+                   "perfs": {}}
         self.set_user_agent(profile["username"])
         return profile
 


### PR DESCRIPTION
The user may specify a maximum rating difference when searching
for an opponent. Only those bots with a rating less than this difference
in the game to be played will be chosen.

Implements idea from #535.