### PR TITLE
Finalize thread termination

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -143,16 +143,16 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
     logging_listener.start()
 
     try:
-        lichess_main(li,
-                     user_profile,
-                     config,
-                     logging_level,
-                     log_filename,
-                     challenge_queue,
-                     control_queue,
-                     correspondence_queue,
-                     logging_queue,
-                     one_game)
+        lichess_bot_main(li,
+                         user_profile,
+                         config,
+                         logging_level,
+                         log_filename,
+                         challenge_queue,
+                         control_queue,
+                         correspondence_queue,
+                         logging_queue,
+                         one_game)
     finally:
         control_stream.terminate()
         control_stream.join()
@@ -162,16 +162,16 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
         logging_listener.join()
 
 
-def lichess_main(li,
-                 user_profile,
-                 config,
-                 logging_level,
-                 log_filename,
-                 challenge_queue,
-                 control_queue,
-                 correspondence_queue,
-                 logging_queue,
-                 one_game):
+def lichess_bot_main(li,
+                     user_profile,
+                     config,
+                     logging_level,
+                     log_filename,
+                     challenge_queue,
+                     control_queue,
+                     correspondence_queue,
+                     logging_queue,
+                     one_game):
     busy_processes = 0
     queued_processes = 0
 


### PR DESCRIPTION
If an exception escapes start() and causes lichess-bot to quit, the program will hang due to the background processes control_stream, correspondence_pinger, and logging_listener never being terminated and joined. These changes make sure that these processes are ended completely before the exception is passed up to the __main__ portion of the code. A new function was created to run the main lichess-bot loop so that much less code needed to be indented for the try-finally blocks.