### PR TITLE
Close background process and transport of engines

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -221,6 +221,7 @@ class EngineWrapper:
 
     def quit(self):
         self.engine.quit()
+        self.engine.close()
 
 
 class UCIEngine(EngineWrapper):


### PR DESCRIPTION
Before this change, a Windows engine had a good chance of never closing
and endless messages of the form

<IocpProactor overlapped#=1 result#=0> is running after closing for 1788.2 seconds

would be printed to the DEBUG logging stream once a second.