### PR TITLE
Do not challenge bots from blocked accounts

### DIFF
--- a/lichess.py
+++ b/lichess.py
@@ -24,7 +24,8 @@ ENDPOINTS = {
     "online_bots": "/api/bot/online",
     "challenge": "/api/challenge/{}",
     "cancel": "/api/challenge/{}/cancel",
-    "status": "/api/users/status"
+    "status": "/api/users/status",
+    "public_data": "/api/user/{}"
 }
 
 
@@ -159,6 +160,9 @@ class Lichess:
     def is_online(self, user_id):
         user = self.api_get(ENDPOINTS["status"], params={"ids": user_id})
         return user and user[0].get("online")
+
+    def get_public_data(self, user_name):
+        return self.api_get(ENDPOINTS["public_data"].format(user_name))
 
     def reset_connection(self):
         self.session.close()

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -90,9 +90,7 @@ class Matchmaking:
         base_time = self.get_time("challenge_initial_time", 60)
         increment = self.get_time("challenge_increment", 2)
         days = self.get_time("challenge_days")
-
-        game_duration = base_time + increment * 40
-        game_type = game_category(variant, days, game_duration)
+        game_type = game_category(variant, base_time, increment, days)
 
         min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 600
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
@@ -146,7 +144,8 @@ class Matchmaking:
         self.block_list.append(username)
 
 
-def game_category(variant, days, game_duration):
+def game_category(variant, base_time, increment, days):
+    game_duration = base_time + increment * 40
     if variant != "standard":
         return variant
     elif days:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -99,6 +99,7 @@ class Matchmaking:
             return (bot["username"] != self.username
                     and not bot.get("disabled")
                     and (allow_tos_violation or not bot.get("tosViolation"))  # Terms of Service
+                    and not bot.get("blocking")
                     and perf.get("games", 0) > 0
                     and min_rating <= perf.get("rating", 0) <= max_rating)
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -133,5 +133,5 @@ class Matchmaking:
         self.challenge_id = challenge_id
 
     def add_to_block_list(self, username):
-        logger.info(f"Adding {username} to block list.")
+        logger.info(f"Will not challenge {username} again during this session.")
         self.block_list.append(username)

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -92,18 +92,7 @@ class Matchmaking:
         days = self.get_time("challenge_days")
 
         game_duration = base_time + increment * 40
-        if variant != "standard":
-            game_type = variant
-        elif days:
-            game_type = "correspondence"
-        elif game_duration < 179:
-            game_type = "bullet"
-        elif game_duration < 479:
-            game_type = "blitz"
-        elif game_duration < 1499:
-            game_type = "rapid"
-        else:
-            game_type = "classical"
+        game_type = game_category(variant, days, game_duration)
 
         min_rating = self.matchmaking_cfg.get("opponent_min_rating") or 600
         max_rating = self.matchmaking_cfg.get("opponent_max_rating") or 4000
@@ -155,3 +144,18 @@ class Matchmaking:
     def add_to_block_list(self, username):
         logger.info(f"Will not challenge {username} again during this session.")
         self.block_list.append(username)
+
+
+def game_category(variant, days, game_duration):
+    if variant != "standard":
+        return variant
+    elif days:
+        return "correspondence"
+    elif game_duration < 179:
+        return "bullet"
+    elif game_duration < 479:
+        return "blitz"
+    elif game_duration < 1499:
+        return "rapid"
+    else:
+        return "classical"


### PR DESCRIPTION
After choosing a bot to challenge, this PR checks if the target bot is an account that is blocked by the user. If it is, then no challenge is issued and the name of the bot is added to an internal block list to prevent that bot from being challenged again. A bot is also added to the internal block list if an error occurs while attempting to challenge it, usually because the target bot blocks the user's bot's account.

The test for blocking occurs only after a random selection is made to prevent rate limiting when fetching the public data necessary to check for blocked accounts. Unlike `tosViolation`, blocking information is not included in the data returned from `Lichess.get_online_bots()` and must be queried separately.

Fixes #537.