### PR TITLE
Delay challenging bot after challenge decline

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `opponent_rating_difference`: The maximum difference between the bot's rating and the opponent bot's rating.
   - `opponent_allow_tos_violation`: Whether to challenge bots that violated Lichess Terms of Service. Note that even rated games against them will not affect ratings.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
+  - `delay_after_decline`: Whether to delay challenging a bot after that bot declines a challenge.
 
 If there are entries for both real-time (`challenge_initial_time` and/or `challenge_increment`) and correspondence games (`challenge_days`), the challenge will be a random choice between the two.
 
@@ -284,6 +285,7 @@ matchmaking:
   opponent_rating_difference: 100
   opponent_allow_tos_violation: true
   challenge_mode: "random"
+  delay_after_decline: false
 ```
 
 ## Lichess Upgrade to Bot Account

--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `opponent_rating_difference`: The maximum difference between the bot's rating and the opponent bot's rating.
   - `opponent_allow_tos_violation`: Whether to challenge bots that violated Lichess Terms of Service. Note that even rated games against them will not affect ratings.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
-  - `delay_after_decline`: Whether and how to delay challenging a bot after that bot declines a challenge. Options are "none", "coarse", and "fine".
-    - "none" does not delay challenging a bot that declined a challenge.
-    - "coarse" will delay challenging a bot to any type of game for a set time.
-    - "fine" will delay challenging a bot to the same kind of game that was declined for a set time.
+  - `delay_after_decline`: Whether and how to delay challenging a bot after that bot declines a challenge. Options are `none`, `coarse`, and `fine`.
+    - `none` does not delay challenging a bot that declined a challenge.
+    - `coarse` will delay challenging a bot to any type of game for a set time.
+    - `fine` will delay challenging a bot to the same kind of game that was declined for a set time.
 
 If there are entries for both real-time (`challenge_initial_time` and/or `challenge_increment`) and correspondence games (`challenge_days`), the challenge will be a random choice between the two.
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,10 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `opponent_rating_difference`: The maximum difference between the bot's rating and the opponent bot's rating.
   - `opponent_allow_tos_violation`: Whether to challenge bots that violated Lichess Terms of Service. Note that even rated games against them will not affect ratings.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
-  - `delay_after_decline`: Whether to delay challenging a bot after that bot declines a challenge.
+  - `delay_after_decline`: Whether and how to delay challenging a bot after that bot declines a challenge. Options are "none", "coarse", and "fine".
+    - "none" does not delay challenging a bot that declined a challenge.
+    - "coarse" will delay challenging a bot to any type of game for a set time.
+    - "fine" will delay challenging a bot to the same kind of game that was declined for a set time.
 
 If there are entries for both real-time (`challenge_initial_time` and/or `challenge_increment`) and correspondence games (`challenge_days`), the challenge will be a random choice between the two.
 
@@ -287,7 +290,7 @@ matchmaking:
   opponent_rating_difference: 100
   opponent_allow_tos_violation: true
   challenge_mode: "random"
-  delay_after_decline: false
+  delay_after_decline: none
 ```
 
 ## Lichess Upgrade to Bot Account

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ If there are entries for both real-time (`challenge_initial_time` and/or `challe
 
 If there are entries for both absolute ratings (`opponent_min_rating` and `opponent_max_rating`) and rating difference (`opponent_rating_difference`), the rating difference takes precendence.
 
+The `delay_after_decline` option can be useful if your matchmaking settings result in a lot of declined challenges. The bots that accept challenges will be challenged more often than those that have declined. The delay is only temporary, so bots that decline a challenge will eventually be challenged again.
+
 ```yml
 matchmaking:
   allow_matchmaking: false

--- a/config.yml.default
+++ b/config.yml.default
@@ -162,3 +162,4 @@ matchmaking:
   opponent_rating_difference: 100 # The maximum difference in rating between the bot's rating and opponent's rating.
   opponent_allow_tos_violation: true # Set to 'false' to prevent challenging bots that violated Lichess Terms of Service.
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.
+  delay_after_decline: false  # If a bot declines a challenge, delay issuing another challenge to that bot.

--- a/config.yml.default
+++ b/config.yml.default
@@ -162,4 +162,4 @@ matchmaking:
   opponent_rating_difference: 100 # The maximum difference in rating between the bot's rating and opponent's rating.
   opponent_allow_tos_violation: true # Set to 'false' to prevent challenging bots that violated Lichess Terms of Service.
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.
-  delay_after_decline: false  # If a bot declines a challenge, delay issuing another challenge to that bot.
+  delay_after_decline: none  # If a bot declines a challenge, delay issuing another challenge to that bot. Possible options are 'none', 'coarse', and 'fine'.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -245,6 +245,7 @@ def lichess_bot_main(li,
                 opponent = event["challenge"]["destUser"]["name"]
                 reason = event["challenge"]["declineReason"]
                 logger.info(f"{opponent} declined {chlng}: {reason}")
+                matchmaker.declined_challenge(opponent)
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
                 if matchmaker.challenge_id == game_id:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -241,11 +241,7 @@ def lichess_bot_main(li,
                 elif chlng.id != matchmaker.challenge_id:
                     li.decline_challenge(chlng.id, reason=decline_reason)
             elif event["type"] == "challengeDeclined":
-                chlng = model.Challenge(event["challenge"], user_profile)
-                opponent = event["challenge"]["destUser"]["name"]
-                reason = event["challenge"]["declineReason"]
-                logger.info(f"{opponent} declined {chlng}: {reason}")
-                matchmaker.declined_challenge(opponent)
+                matchmaker.declined_challenge(event)
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
                 if matchmaker.challenge_id == game_id:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -114,7 +114,7 @@ class Matchmaking:
         online_bots = list(filter(is_suitable_opponent, online_bots))
 
         def ready_for_challenge(bot):
-            return self.get_delay_timer(bot["username"], variant, game_type, mode).is_expired()
+            return self.delay_timers[bot["username"]].is_expired()
 
         ready_bots = list(filter(ready_for_challenge, online_bots))
         if ready_bots:
@@ -158,19 +158,11 @@ class Matchmaking:
             return
 
         # Add one hour to delay each time a challenge is declined.
-        mode = "rated" if challenge.rated else "casual"
-        delay_timer = self.get_delay_timer(opponent,
-                                           challenge.variant,
-                                           challenge.speed,
-                                           mode)
+        delay_timer = self.delay_timers[opponent]
         delay_timer.duration += 3600
         delay_timer.reset()
         hours = "hours" if delay_timer.duration > 3600 else "hour"
-        logger.info(f"Will not challenge {opponent} to a {mode} {challenge.speed} "
-                    f"{challenge.variant} game for {int(delay_timer.duration/3600)} {hours}.")
-
-    def get_delay_timer(self, opponent_name, variant, time_control, rated_mode):
-        return self.delay_timers[(opponent_name, variant, time_control, rated_mode)]
+        logger.info(f"Will not challenge {opponent} for {int(delay_timer.duration/3600)} {hours}.")
 
 
 def game_category(variant, base_time, increment, days):

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -114,7 +114,7 @@ class Matchmaking:
         online_bots = list(filter(is_suitable_opponent, online_bots))
 
         def ready_for_challenge(bot):
-            return self.delay_timers[bot["username"]].is_expired()
+            return self.get_delay_timer(bot["username"], variant, game_type, mode).is_expired()
 
         ready_bots = list(filter(ready_for_challenge, online_bots))
         if ready_bots:
@@ -158,11 +158,19 @@ class Matchmaking:
             return
 
         # Add one hour to delay each time a challenge is declined.
-        delay_timer = self.delay_timers[opponent]
+        mode = "rated" if challenge.rated else "casual"
+        delay_timer = self.get_delay_timer(opponent,
+                                           challenge.variant,
+                                           challenge.speed,
+                                           mode)
         delay_timer.duration += 3600
         delay_timer.reset()
         hours = "hours" if delay_timer.duration > 3600 else "hour"
-        logger.info(f"Will not challenge {opponent} for {int(delay_timer.duration/3600)} {hours}.")
+        logger.info(f"Will not challenge {opponent} to a {mode} {challenge.speed} "
+                    f"{challenge.variant} game for {int(delay_timer.duration/3600)} {hours}.")
+
+    def get_delay_timer(self, opponent_name, variant, time_control, rated_mode):
+        return self.delay_timers[(opponent_name, variant, time_control, rated_mode)]
 
 
 def game_category(variant, base_time, increment, days):

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -151,7 +151,7 @@ class Matchmaking:
         if not challenge.from_self:
             return
 
-        # add one hour to delay each time a challenge is declined
+        # Add one hour to delay each time a challenge is declined.
         mode = "rated" if challenge.rated else "casual"
         delay_timer = self.get_delay_timer(opponent,
                                            challenge.variant,

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -105,7 +105,6 @@ class Matchmaking:
             perf = bot.get("perfs", {}).get(game_type, {})
             return (bot["username"] != self.username()
                     and bot["username"] not in self.block_list
-                    and self.get_delay_timer(bot["username"], variant, game_type, mode).is_expired()
                     and not bot.get("disabled")
                     and (allow_tos_violation or not bot.get("tosViolation"))  # Terms of Service
                     and perf.get("games", 0) > 0
@@ -113,6 +112,13 @@ class Matchmaking:
 
         online_bots = self.li.get_online_bots()
         online_bots = list(filter(is_suitable_opponent, online_bots))
+
+        def ready_for_challenge(bot):
+            return self.get_delay_timer(bot["username"], variant, game_type, mode).is_expired()
+
+        ready_bots = list(filter(ready_for_challenge, online_bots))
+        if ready_bots:
+            online_bots = ready_bots
 
         try:
             bot_username = None

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -148,6 +148,8 @@ class Matchmaking:
         opponent = event["challenge"]["destUser"]["name"]
         reason = event["challenge"]["declineReason"]
         logger.info(f"{opponent} declined {challenge}: {reason}")
+        if not challenge.from_self:
+            return
 
         # add one hour to delay each time a challenge is declined
         mode = "rated" if challenge.rated else "casual"

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -79,13 +79,12 @@ class Matchmaking:
             self.user_profile = self.li.get_profile()
 
     def choose_opponent(self):
-        variant = self.matchmaking_cfg.get("challenge_variant") or "random"
-        if variant == "random":
-            variant = random.choice(self.variants)
+        def get_random_config_value(parameter, choices):
+            value = self.matchmaking_cfg.get(parameter) or "random"
+            return value if value != "random" else random.choice(choices)
 
-        mode = self.matchmaking_cfg.get("challenge_mode") or "random"
-        if mode == "random":
-            mode = random.choice(["casual", "rated"])
+        variant = get_random_config_value("challenge_variant", self.variants)
+        mode = get_random_config_value("challenge_mode", ["casual", "rated"])
 
         base_time = self.get_time("challenge_initial_time", 60)
         increment = self.get_time("challenge_increment", 2)

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -154,7 +154,7 @@ class Matchmaking:
         opponent = event["challenge"]["destUser"]["name"]
         reason = event["challenge"]["declineReason"]
         logger.info(f"{opponent} declined {challenge}: {reason}")
-        if not challenge.from_self:
+        if not challenge.from_self or not self.matchmaking_cfg.get("delay_after_decline"):
             return
 
         # Add one hour to delay each time a challenge is declined.

--- a/timer.py
+++ b/timer.py
@@ -7,7 +7,7 @@ class Timer:
         self.reset()
 
     def is_expired(self):
-        return self.time_since_reset() > self.duration
+        return self.time_since_reset() >= self.duration
 
     def reset(self):
         self.starting_time = time.time()


### PR DESCRIPTION
If an opponent declines a challenge, do not challenge them again for one hour. Increase the delay by another hour on every subsequent decline.

Will close #538.