### PR TITLE
Make response to !eval more readable

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -3,7 +3,6 @@ import chess.engine
 import subprocess
 import logging
 from enum import Enum
-from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
@@ -240,9 +239,7 @@ class EngineWrapper:
                 info["ponderpv"] = " ".join(ponder_pv)
             except IndexError:
                 pass
-        stats = [f"{to_readable_key(stat)}: {to_readable_value(stat, info)}" for stat in stats if stat in info]
-
-        return stats
+        return [f"{to_readable_key(stat)}: {to_readable_value(stat, info)}" for stat in stats if stat in info]
 
     def get_opponent_info(self, game):
         pass


### PR DESCRIPTION
The bot responds always from white's perpective.
Score: From: `PovScore(Score(200), WHITE)` to `2.0`
WDL: From: `PovWdl(Wdl(wins=900, draws=90, losses=10), WHITE)` to `94.5%`
Nodes (and tbhits): From `12345678` to `12.3M`
NPS: From `123456` to `123.4Knps`
Time: From `4678` to `4.7`
Hashfull: From `389` to `38.9%`

Renamed
- `wdl` to `winrate`
- `ponderpv` to `PV`
- `nps` to `speed`
- `score` to `evaluation`

The stats are also capitalized (e.g. `Winrate`).

Reordered the stats to have a more logical order.
From: `["depth", "nps", "nodes", "score", "ponderpv"]`
To: `["score", "wdl", "depth", "nodes", "nps", "ponderpv"]`