### PR TITLE
Fix error when there is no ponderpv

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -193,7 +193,7 @@ class EngineWrapper:
     def get_stats(self, for_chat=False):
         info = self.last_move_info.copy()
         stats = ["depth", "nps", "nodes", "score", "ponderpv"]
-        if for_chat and "ponderpv" in stats:
+        if for_chat and "ponderpv" in stats and "ponderpv" in info:
             bot_stats = [f"{stat}: {info[stat]}" for stat in stats if stat in info and stat != "ponderpv"]
             len_bot_stats = len(", ".join(bot_stats)) + PONDERPV_CHARACTERS
             ponder_pv = info["ponderpv"].split()


### PR DESCRIPTION
When moves were only played by online opening books, the bot will crash when responding to `!eval`.
![1](https://user-images.githubusercontent.com/40605232/191534353-d73b6862-d700-4d1c-a510-ec2ebc0be62a.jpg)