### PR TITLE
Restart bot if it is offline

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -204,7 +204,7 @@ def lichess_bot_main(li,
                       logging_level]
 
     with multiprocessing.pool.Pool(max_games + 1) as pool:
-        while not terminated:
+        while not terminated and not restart:
             try:
                 event = control_queue.get()
                 if event.get("type") != "ping":
@@ -309,7 +309,6 @@ def lichess_bot_main(li,
                 if not li.is_online(user_profile["id"]):
                     logger.info("Will restart lichess-bot")
                     restart = True
-                    terminated = True
                 last_check_online_time.reset()
 
             control_queue.task_done()
@@ -641,7 +640,6 @@ if __name__ == "__main__":
     try:
         while restart:
             restart = False
-            terminated = False
             start_lichess_bot()
             time.sleep(10 if restart else 0)
     except Exception:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -122,7 +122,6 @@ def game_error_handler(error):
 
 
 def start(li, user_profile, config, logging_level, log_filename, one_game=False):
-    global restart, terminated
     logger.info(f"You're now connected to {config['url']} and awaiting challenges.")
     manager = multiprocessing.Manager()
     challenge_queue = manager.list()
@@ -176,6 +175,7 @@ def lichess_bot_main(li,
                      correspondence_queue,
                      logging_queue,
                      one_game):
+    global restart, terminated
     busy_processes = 0
     queued_processes = 0
 
@@ -1125,6 +1125,6 @@ if __name__ == "__main__":
             restart = False
             terminated = False
             start_lichess_bot()
-            time.sleep(10)
+            time.sleep(10 if restart else 0)
     except Exception:
         logger.exception("Quitting lichess-bot due to an error:")

--- a/lichess.py
+++ b/lichess.py
@@ -167,8 +167,3 @@ class Lichess:
 
     def get_public_data(self, user_name):
         return self.api_get(ENDPOINTS["public_data"].format(user_name))
-
-    def reset_connection(self):
-        self.session.close()
-        self.session = requests.Session()
-        self.session.headers.update(self.header)

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -178,6 +178,6 @@ class Lichess:
 
     def online_book_get(self, path, params=None):
         return
-
-    def reset_connection(self):
-        return
+    
+    def is_online(self, user_id):
+        return True

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -178,6 +178,6 @@ class Lichess:
 
     def online_book_get(self, path, params=None):
         return
-    
+
     def is_online(self, user_id):
         return True

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -160,6 +160,7 @@ def run_bot(CONFIG, logging_level):
     if user_profile.get("title") != "BOT":
         return "0"
     lichess_bot.logger.info(f"Welcome {username}!")
+    lichess_bot.restart = False
 
     thr = threading.Thread(target=thread_for_test)
     thr.start()


### PR DESCRIPTION
If the bot is offline, restart lichess-bot.

The logs provided by theoden8 (https://github.com/ShailChoksi/lichess-bot/issues/222#issuecomment-1280002750) show that the bot successfully restarted. While it is possible the `Resetting dropped connection` would have solved the problem by itself, it didn't for ianagbip1oti (https://github.com/ShailChoksi/lichess-bot/issues/222#issuecomment-1221612999). This makes me think that the change actually helped, so while this isn't conclusive evidence, it also doesn't seem to make the problem worse.