### PR TITLE
Suggest moves from EGTBs to the engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ Besides the above, there are many possible options within `config.yml` for confi
     - Configurations common to all:
         - `enabled`: Whether to use the database at all.
         - `min_time`: The minimum time in seconds on the game clock necessary to allow the online database to be consulted.
-    - Configurations only in `chessdb_book` and `lichess_cloud_analysis`:
-        - `move_quality`: Choice of `"all"` (`chessdb_book` only), `"good"`, or `"best"`.
+        - `move_quality`: Choice of `"all"` (`chessdb_book` only), `"good"`, `"best"`, or `"suggest"` (`online_egtb` only).
             - `all`: Choose a random move from all legal moves.
             - `best`: Choose only the highest scoring move.
             - `good`: Choose randomly from the top moves. In `lichess_cloud_analysis`, the top moves list is controlled by `max_score_difference`. In `chessdb_book`, the top list is controlled by the online source.
+            - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned.
+    - Configurations only in `chessdb_book` and `lichess_cloud_analysis`:
         - `min_depth`: The minimum search depth for a move evaluation for a database move to be accepted.
     - Configurations only in `chessdb_book`:
         - `contribute`: Send the current board position to chessdb for later analysis.
@@ -112,6 +113,7 @@ Besides the above, there are many possible options within `config.yml` for confi
         - `move_quality`: Choice of `"good"`, or `"best"`.
             - `best`: Choose only the highest scoring move. When using `syzygy`, if `.*tbz` files are not provided, the bot will attempt to get a move using `move_quality` = `good`.
             - `good`: Choose randomly from the top moves.
+            - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned.
     - Configurations only in `gaviota`:
         - `min_dtm_to_consider_as_wdl_1`: The minimum DTM to consider as syzygy WDL=1/-1. Setting it to 100 will disable it.
 - `engine_options`: Command line options to pass to the engine on startup. For example, the `config.yml.default` has the configuration

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Besides the above, there are many possible options within `config.yml` for confi
             - `all`: Choose a random move from all legal moves.
             - `best`: Choose only the highest scoring move.
             - `good`: Choose randomly from the top moves. In `lichess_cloud_analysis`, the top moves list is controlled by `max_score_difference`. In `chessdb_book`, the top list is controlled by the online source.
-            - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned.
+            - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned. Can't be used with XBoard engines.
     - Configurations only in `chessdb_book` and `lichess_cloud_analysis`:
         - `min_depth`: The minimum search depth for a move evaluation for a database move to be accepted.
     - Configurations only in `chessdb_book`:
@@ -113,7 +113,7 @@ Besides the above, there are many possible options within `config.yml` for confi
         - `move_quality`: Choice of `"good"`, or `"best"`.
             - `best`: Choose only the highest scoring move. When using `syzygy`, if `.*tbz` files are not provided, the bot will attempt to get a move using `move_quality` = `good`.
             - `good`: Choose randomly from the top moves.
-            - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned.
+            - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned. Can't be used with XBoard engines.
     - Configurations only in `gaviota`:
         - `min_dtm_to_consider_as_wdl_1`: The minimum DTM to consider as syzygy WDL=1/-1. Setting it to 100 will disable it.
 - `engine_options`: Command line options to pass to the engine on startup. For example, the `config.yml.default` has the configuration

--- a/config.py
+++ b/config.py
@@ -57,14 +57,13 @@ def load_config(config_file):
                       f"The engine {engine} file does not exist.")
         config_assert(os.access(engine, os.X_OK) or CONFIG["engine"]["protocol"] == "homemade",
                       f"The engine {engine} doesn't have execute (x) permission. Try: chmod +x {engine}")
-        config_assert(CONFIG["engine"]["protocol"] != "xboard" or CONFIG["engine"]["online_moves"]["online_egtb"][
-            "move_quality"] != "suggest" or not CONFIG["engine"]["online_moves"]["online_egtb"]["enabled"],
-                      "XBoard engines can't be used with `move_quality` set to `suggest` in online_egtb.")
-        config_assert(CONFIG["engine"]["protocol"] != "xboard" or CONFIG["engine"]["lichess_bot_tbs"]["syzygy"][
-            "move_quality"] != "suggest" or not CONFIG["engine"]["lichess_bot_tbs"]["syzygy"]["enabled"],
-                      "XBoard engines can't be used with `move_quality` set to `suggest` in syzygy.")
-        config_assert(CONFIG["engine"]["protocol"] != "xboard" or CONFIG["engine"]["lichess_bot_tbs"]["gaviota"][
-            "move_quality"] != "suggest" or not CONFIG["engine"]["lichess_bot_tbs"]["gaviota"]["enabled"],
-                      "XBoard engines can't be used with `move_quality` set to `suggest` in gaviota.")
+
+        if CONFIG["engine"]["protocol"] == "xboard":
+            for section, subsection in (("online_moves", "online_egtb"),
+                                        ("lichess_bot_tbs", "syzygy"),
+                                        ("lichess_bot_tbs", "gaviota")):
+                online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
+                config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
+                              f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
 
     return CONFIG

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ def check_config_section(config, data_name, data_type, subsection=""):
     config_part = config[subsection] if subsection else config
     sub = f"`{subsection}` sub" if subsection else ""
     data_location = f"`{data_name}` subsection in `{subsection}`" if subsection else f"Section `{data_name}`"
-    type_error_message = {str:  f"{data_location} must be a string wrapped in quotes.",
+    type_error_message = {str: f"{data_location} must be a string wrapped in quotes.",
                           dict: f"{data_location} must be a dictionary with indented keys followed by colons."}
     config_assert(data_name in config_part, f"Your config.yml does not have required {sub}section `{data_name}`.")
     config_assert(isinstance(config_part[data_name], data_type), type_error_message[data_type])
@@ -57,5 +57,14 @@ def load_config(config_file):
                       f"The engine {engine} file does not exist.")
         config_assert(os.access(engine, os.X_OK) or CONFIG["engine"]["protocol"] == "homemade",
                       f"The engine {engine} doesn't have execute (x) permission. Try: chmod +x {engine}")
+        config_assert(CONFIG["engine"]["protocol"] != "xboard" or CONFIG["engine"]["online_moves"]["online_egtb"][
+            "move_quality"] != "suggest" or not CONFIG["engine"]["online_moves"]["online_egtb"]["enabled"],
+                      "XBoard engines can't be used with `move_quality` set to `suggest` in online_egtb.")
+        config_assert(CONFIG["engine"]["protocol"] != "xboard" or CONFIG["engine"]["lichess_bot_tbs"]["syzygy"][
+            "move_quality"] != "suggest" or not CONFIG["engine"]["lichess_bot_tbs"]["syzygy"]["enabled"],
+                      "XBoard engines can't be used with `move_quality` set to `suggest` in syzygy.")
+        config_assert(CONFIG["engine"]["protocol"] != "xboard" or CONFIG["engine"]["lichess_bot_tbs"]["gaviota"][
+            "move_quality"] != "suggest" or not CONFIG["engine"]["lichess_bot_tbs"]["gaviota"]["enabled"],
+                      "XBoard engines can't be used with `move_quality` set to `suggest` in gaviota.")
 
     return CONFIG

--- a/config.yml.default
+++ b/config.yml.default
@@ -51,21 +51,21 @@ engine:                      # Engine settings.
       min_time: 20
       max_pieces: 7
       source: "lichess"      # One of "lichess", "chessdb".
-      move_quality: "best"   # One of "good", "best".
+      move_quality: "best"   # One of "good", "best", "suggest" (it takes all the "good" moves and tells the engine to only consider these; will move instantly if there is only 1 "good" move).
   lichess_bot_tbs:
     syzygy:
       enabled: false
       paths:
         - "engines/syzygy"
       max_pieces: 7
-      move_quality: "best"   # One of "good", "best".
+      move_quality: "best"   # One of "good", "best", "suggest" (it takes all the "good" moves and tells the engine to only consider these; will move instantly if there is only 1 "good" move).
     gaviota:
       enabled: false
       paths:
         - "engines/gaviota"
       max_pieces: 5
       min_dtm_to_consider_as_wdl_1: 120  # The minimum dtm to consider as syzygy wdl=1/-1. Set to 100 to disable.
-      move_quality: "best"   # One of "good", "best".
+      move_quality: "best"   # One of "good", "best", "suggest" (it takes all the "good" moves and tells the engine to only consider these; will move instantly if there is only 1 "good" move).
 # engine_options:            # Any custom command line params to pass to the engine.
 #   cpuct: 3.1
   homemade_options:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -813,7 +813,7 @@ def get_syzygy(board, syzygy_cfg):
                 good_moves = [move for move, wdl in moves.items() if wdl == best_wdl]
                 logger.debug("Found a move using 'move_quality'='good'. We didn't find an '.rtbz' file for this endgame."
                              if move_quality == "best" else "")
-                if move_quality == "suggest":
+                if move_quality == "suggest" and len(good_moves) > 1:
                     move = good_moves
                     logger.info(f"Suggesting moves from syzygy (wdl: {best_wdl})")
                 else:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1,5 +1,8 @@
 import os
 import chess.engine
+import chess.polyglot
+import chess.syzygy
+import chess.gaviota
 import subprocess
 import logging
 import time

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -222,7 +222,7 @@ class EngineWrapper:
                                   info=chess.engine.INFO_ALL,
                                   ponder=ponder,
                                   draw_offered=draw_offered,
-                                  root_moves=root_moves)
+                                  root_moves=root_moves if isinstance(root_moves, list) else None)
         # Use null_score to have no effect on draw/resign decisions
         null_score = chess.engine.PovScore(chess.engine.Mate(1), board.turn)
         self.scores.append(result.info.get("score", null_score))
@@ -654,7 +654,9 @@ def get_egtb_move(board, lichess_bot_tbs, draw_or_resign_cfg):
         resign = bool(can_resign and resign_on_egtb_loss and wdl == -2)
         wdl_to_score = {2: 9900, 1: 500, 0: 0, -1: -500, -2: -9900}
         comment = {"score": chess.engine.PovScore(chess.engine.Cp(wdl_to_score[wdl]), board.turn)}
-        return chess.engine.PlayResult(best_move, None, comment, draw_offered=offer_draw, resigned=resign)
+        if isinstance(best_move, chess.Move):
+            return chess.engine.PlayResult(best_move, None, comment, draw_offered=offer_draw, resigned=resign)
+        return best_move
     return chess.engine.PlayResult(None, None)
 
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -1,10 +1,7 @@
 import argparse
 import chess
 import chess.pgn
-import chess.syzygy
-import chess.gaviota
 from chess.variant import find_variant
-import chess.polyglot
 import engine_wrapper
 import model
 import matchmaking

--- a/strategies.py
+++ b/strategies.py
@@ -54,7 +54,7 @@ class MinimalEngine(EngineWrapper):
             "name": self.engine_name
         }
 
-    def search(self, board, time_limit, ponder, draw_offered):
+    def search(self, board, time_limit, ponder, draw_offered, root_moves):
         """
         The method to be implemented in your homemade engine
 


### PR DESCRIPTION
Suggests moves from EGTB to the engine. The moves that are suggested are all the moves that could have been chosen with `move_quality="good"`. This will fix the problem of EGTBs playing dumb moves (e.g. `8/8/8/8/1p6/1K1R4/8/2k5 w - - 0 1`), where the engine instead of mating will first pick up material. Getting the move from lichess will fix this problem for the most part because it also has DTM, but it doesn't have DTM for 6 or 7 men positions.

This can also be done with `lichess_cloud_analysis` but I don't know if this is useful.

Also had to move some code to fix the flake8 errors that the initial addition created.