### PR TITLE
Add max retries for online moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Besides the above, there are many possible options within `config.yml` for confi
     2. `lichess_cloud_analysis`: Consults [Lichess' own position analysis database](https://lichess.org/api#operation/apiCloudEval).
     3. `online_egtb`: Consults either the online Syzygy 7-piece endgame tablebase [hosted by Lichess](https://lichess.org/blog/W3WeMyQAACQAdfAL/7-piece-syzygy-tablebases-are-complete) or the chessdb listed above.
     - `max_out_of_book_moves`: Stop using online opening books after they don't have a move for `max_out_of_book_moves` positions. Doesn't apply to the online endgame tablebases.
+    - `max_retries`: The maximum amount of retries when getting an online move.
     - Configurations common to all:
         - `enabled`: Whether to use the database at all.
         - `min_time`: The minimum time in seconds on the game clock necessary to allow the online database to be consulted.

--- a/config.yml.default
+++ b/config.yml.default
@@ -33,6 +33,7 @@ engine:                      # Engine settings.
     offer_draw_pieces: 10    # Only if the pieces on board are less than or equal to this value, the bot offers/accepts draw.
   online_moves:
     max_out_of_book_moves: 10 # Stop using online opening books after they don't have a move for 'max_out_of_book_moves' positions. Doesn't apply to the online endgame tablebases.
+    max_retries: 2           # The maximum amount of retries when getting an online move.
     chessdb_book:
       enabled: false
       min_time: 20

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -1098,7 +1098,7 @@ def start_lichess_bot():
     logging_configurer(logging_level, args.logfile)
     logger.info(intro(), extra={"highlighter": None})
     CONFIG = load_config(args.config or "./config.yml")
-    max_retries = (CONFIG["engine"].get("online_moves") or {}).get("max_retries") or 1
+    max_retries = (CONFIG["engine"].get("online_moves") or {}).get("max_retries") or 2
     li = lichess.Lichess(CONFIG["token"], CONFIG["url"], __version__, logging_level, max_retries)
 
     user_profile = li.get_profile()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -1098,7 +1098,8 @@ def start_lichess_bot():
     logging_configurer(logging_level, args.logfile)
     logger.info(intro(), extra={"highlighter": None})
     CONFIG = load_config(args.config or "./config.yml")
-    li = lichess.Lichess(CONFIG["token"], CONFIG["url"], __version__, logging_level)
+    max_retries = (CONFIG["engine"].get("online_moves") or {}).get("max_retries") or 1
+    li = lichess.Lichess(CONFIG["token"], CONFIG["url"], __version__, logging_level, max_retries)
 
     user_profile = li.get_profile()
     username = user_profile["username"]

--- a/lichess.py
+++ b/lichess.py
@@ -42,7 +42,7 @@ def rate_limit_check(response):
 
 # docs: https://lichess.org/api
 class Lichess:
-    def __init__(self, token, url, version, logging_level):
+    def __init__(self, token, url, version, logging_level, max_retries):
         self.version = version
         self.header = {
             "Authorization": f"Bearer {token}"
@@ -52,6 +52,7 @@ class Lichess:
         self.session.headers.update(self.header)
         self.set_user_agent("?")
         self.logging_level = logging_level
+        self.max_retries = max_retries
 
     def is_final(exception):
         return isinstance(exception, HTTPError) and exception.response.status_code < 500
@@ -159,7 +160,17 @@ class Lichess:
                              raise_for_status=False)
 
     def online_book_get(self, path, params=None):
-        return self.session.get(path, timeout=2, params=params).json()
+        @backoff.on_exception(backoff.constant,
+                              (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
+                              max_time=60,
+                              max_tries=self.max_retries,
+                              interval=0.1,
+                              giveup=self.is_final,
+                              backoff_log_level=logging.DEBUG,
+                              giveup_log_level=logging.DEBUG)
+        def online_book_get():
+            return self.session.get(path, timeout=2, params=params).json()
+        return online_book_get()
 
     def is_online(self, user_id):
         user = self.api_get(ENDPOINTS["status"], params={"ids": user_id})


### PR DESCRIPTION
Sometimes 1 try is way to little, especially when having an unstable connection. It adds the option of setting the maximum amount of retries.