### PR TITLE
Add Python 3.11 to workflows

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8, 3.9, "3.10"]
+        python: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ["3.10"]
+        python: ["3.11"]
 
 
     steps:


### PR DESCRIPTION
- Run tests with Python 3.11
- Add Python 3.11 to python-build which checks that the dependencies can be installed