### PR TITLE
Handle correspondence games with little time left

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -136,7 +136,10 @@ class EngineWrapper:
             elif is_correspondence:
                 best_move = choose_move_time(self,
                                              board,
+                                             game,
                                              correspondence_move_time,
+                                             start_time,
+                                             move_overhead,
                                              can_ponder,
                                              draw_offered)
             else:
@@ -398,7 +401,12 @@ def getHomemadeEngine(name):
     return getattr(strategies, name)
 
 
-def choose_move_time(engine, board, search_time, ponder, draw_offered):
+def choose_move_time(engine, board, game, search_time, start_time, move_overhead, ponder, draw_offered):
+    pre_move_time = int((time.perf_counter_ns() - start_time) / 1e6)
+    overhead = pre_move_time + move_overhead
+    wb = "w" if board.turn == chess.WHITE else "b"
+    clock_time = max(0, game.state[f"{wb}time"] - overhead)
+    search_time = min(search_time, clock_time)
     logger.info(f"Searching for time {search_time}")
     return engine.search_for(board, search_time, ponder, draw_offered)
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -298,7 +298,7 @@ def start_low_time_games(low_time_games, max_games, pool, play_game_args):
     while low_time_games and queued_processes + busy_processes < max_games:
         busy_processes += 1
         log_proc_count("Used", queued_processes, busy_processes)
-        game_id = low_time_games.pop()
+        game_id = low_time_games.pop(0)["id"]
         play_game_args["game_id"] = game_id
         pool.apply_async(play_game,
                          kwds=play_game_args,

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -188,7 +188,7 @@ def lichess_bot_main(li,
 
     startup_correspondence_games = [game["gameId"]
                                     for game in li.get_ongoing_games()
-                                    if game["perf"] == "correspondence"]
+                                    if game["speed"] == "correspondence"]
     low_time_games = []
 
     last_check_online_time = Timer(60 * 60)  # one hour interval
@@ -429,7 +429,7 @@ def play_game(li,
 
     logger.info(f"+++ {game}")
 
-    is_correspondence = game.perf_name == "Correspondence"
+    is_correspondence = game.speed == "correspondence"
     correspondence_cfg = config.get("correspondence") or {}
     correspondence_move_time = correspondence_cfg.get("move_time", 60) * 1000
     correspondence_disconnect_time = correspondence_cfg.get("disconnect_time", 300)


### PR DESCRIPTION
During correspondence games, the time left on the clock is generally ignored since the latter is measured in days. However, if lichess-bot is started when a correspondence game clock is about to expire, the delay caused by queuing plus the move time in the user's config file can result in a bot losing on time. This is fixed in two parts:
- On startup: if it is the bot's move and the time on the bot's clock is less than ten times the sum of the `correspondence: checkin_period` and `correspondence: move_time`, then start the game immediately instead of queuing.
- In a game: if the time left on the bot's clock is less than the `correspondence: move_time` in the user's config file, use the game clock.

One possible problem with this solution is that it doesn't respect concurrency limits. It's possible to have many more correspondence games going simultaneously because they aren't all played simultaneously. With this PR, an arbitrary number of games may start up that is well beyond the user's concurrency limit.