### PR TITLE
Track active game IDs

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -210,8 +210,8 @@ def lichess_bot_main(li,
 
             if event["type"] == "terminated":
                 break
-            elif event["type"] == "local_game_done":
-                active_games.discard(event["id"])
+            elif event["type"] in ["local_game_done", "gameFinish"]:
+                active_games.discard(event["game"]["id"])
                 matchmaker.last_game_ended_delay.reset()
                 log_proc_count("Freed", active_games)
                 one_game_completed = True
@@ -588,7 +588,7 @@ def final_queue_entries(control_queue, correspondence_queue, game, is_correspond
     else:
         logger.info(f"--- {game.url()} Game over")
 
-    control_queue.put_nowait({"type": "local_game_done", "id": game.id})
+    control_queue.put_nowait({"type": "local_game_done", "game": {"id": game.id}})
 
 
 def game_changed(current_game, prior_game):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -162,7 +162,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
 
 def log_proc_count(change, active_games):
     symbol = "+++" if change == "Freed" else "---"
-    logger.info(f"{symbol} Process {change}. Count: {len(active_games)}. IDs: {active_games}")
+    logger.info(f"{symbol} Process {change}. Count: {len(active_games)}. IDs: {active_games or None}")
 
 
 def lichess_bot_main(li,

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -152,10 +152,8 @@ class Matchmaking:
         value = self.matchmaking_cfg.get(parameter) or "random"
         return value if value != "random" else random.choice(choices)
 
-    def challenge(self, queued_processes, busy_processes, challenge_queue):
-        if (queued_processes + busy_processes > 0
-                or challenge_queue
-                or not self.should_create_challenge()):
+    def challenge(self, active_games, challenge_queue):
+        if active_games or challenge_queue or not self.should_create_challenge():
             return
 
         logger.info("Challenging a random bot")


### PR DESCRIPTION
I believe many bug reports related to lichess-bot clients no longer issuing or accepting challenges is due to the counts of active games not being accurate. For example, when a game ends with a threefold draw, lichess sends a game stream event that indicates the bot should keep playing. When the bot tries to play a move, an exception is thrown because the game is over on the lichess server ([I've submitted an issue here](https://github.com/lichess-org/api/issues/214)). This exception ends the `play_game()` thread without creating the `local_game_done` event. This causes the `busy_processes` count to not be decremented. Eventually, after enough of these errors, `busy_processes` will equal `max_games` and no more games will be played until lichess-bot is restarted. Since threefold repetition draws are relatively rare, this would explain why the bug takes so long to manifest.

This PR makes two changes:
1. Keep track of the IDs of active games instead of just the counts. An active game is one that is currently being played or one for which the client bot has accepted a challenge. This will help with bug reporting since it will reveal when too many stale games are preventing bots from playing more games--as is the case for the threefold draw bug above.
2. Remove games from this list when either a `local_game_done` or a `gameFinish` event is received. This fixes at least one cause of lichess-bot stopping all new games.