### PR TITLE
Allow constraining time control for correspondence challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `min_increment`: The minimum value of time increment.
   - `max_base`: The maximum base time for a game.
   - `min_base`: The minimum base time for a game.
+  - `max_days`: The maximum number of days for a correspondence game.
+  - `min_days`: The minimum number of days for a correspondence game.
   - `variants`: An indented list of chess variants that the bot can handle.
 ```yml
   variants:

--- a/config.yml.default
+++ b/config.yml.default
@@ -112,7 +112,8 @@ challenge:                   # Incoming challenges.
   min_increment: 0           # Minimum amount of increment to accept a challenge.
   max_base: 315360000        # Maximum amount of base time to accept a challenge. The max is 315360000 (10 years).
   min_base: 0                # Minimum amount of base time to accept a challenge.
-  max_days:                  # Maximum number of days per move to accept a challenge for a correspondence game.
+  max_days: 14               # Maximum number of days per move to accept a challenge for a correspondence game.
+                             # Unlimited games can be accepted by removing this field or specifying .inf
   min_days: 1                # Minimum number of days per move to accept a challenge for a correspondence game.
   variants:                  # Chess variants to accept (https://lichess.org/variant).
     - standard

--- a/config.yml.default
+++ b/config.yml.default
@@ -112,6 +112,8 @@ challenge:                   # Incoming challenges.
   min_increment: 0           # Minimum amount of increment to accept a challenge.
   max_base: 315360000        # Maximum amount of base time to accept a challenge. The max is 315360000 (10 years).
   min_base: 0                # Minimum amount of base time to accept a challenge.
+  max_days:                  # Maximum number of days per move to accept a challenge for a correspondence game.
+  min_days: 1                # Minimum number of days per move to accept a challenge for a correspondence game.
   variants:                  # Chess variants to accept (https://lichess.org/variant).
     - standard
 #   - fromPosition

--- a/model.py
+++ b/model.py
@@ -12,7 +12,6 @@ class Challenge:
         self.variant = c_info["variant"]["key"]
         self.perf_name = c_info["perf"]["name"]
         self.speed = c_info["speed"]
-        self.time_control_type = c_info.get("timeControl", {}).get("type")
         self.increment = c_info.get("timeControl", {}).get("increment")
         self.base = c_info.get("timeControl", {}).get("limit")
         self.days = c_info.get("timeControl", {}).get("daysPerTurn")
@@ -34,22 +33,22 @@ class Challenge:
         increment_min = challenge_cfg.get("min_increment", 0)
         base_max = challenge_cfg.get("max_base", 315360000)
         base_min = challenge_cfg.get("min_base", 0)
-        days_max = challenge_cfg.get("max_days")
+        days_max = challenge_cfg.get("max_days", math.inf)
         days_min = challenge_cfg.get("min_days", 1)
 
         if self.speed not in speeds:
             return False
 
-        if self.time_control_type == "clock":
+        if self.base is not None and self.increment is not None:
+            # Normal clock game
             return (increment_min <= self.increment <= increment_max
                     and base_min <= self.base <= base_max)
-        elif self.time_control_type == "correspondence":
-            return days_min <= self.days <= (days_max or 10000)
-        elif self.time_control_type == "unlimited":
-            return days_max is None
+        elif self.days is not None:
+            # Correspondence game
+            return days_min <= self.days <= days_max
         else:
-            logger.error(f"Challenge has unknown time control: {self.time_control_type}")
-            return False
+            # Unlimited game
+            return days_max == math.inf
 
     def is_supported_mode(self, challenge_cfg):
         return ("rated" if self.rated else "casual") in challenge_cfg["modes"]

--- a/model.py
+++ b/model.py
@@ -1,3 +1,4 @@
+import math
 from urllib.parse import urljoin
 import logging
 from timer import Timer


### PR DESCRIPTION
This is a feature I added for my fork, maybe you think it makes sense for others as well. My bot has an increasing number of ongoing correspondence games, many unlimited and ignored by their opponents or progressing super slowly (1 move every 2 weeks). This can be avoided by only accepting challenges up to a small number of days per move, which also excludes unlimited time control.

I included `min_days` for symmetry, but can't really imagine a use case. Happy to remove it if you think that's better.

**Some notes on the code:**

Introducing the `time_control_type` tag seemed like the best way to handle the unlimited case, so I made use of it to distinguish clock and correspondence as well.

I think with these checks the `-1` sentinel values should not be needed anymore, unless something is really weird with the API. And if it is, silently skipping those challenges doesn't sound like the best strategy either.
I could add some extra checks that log an error and decline the challenge if an expected field is missing, though.

Relevant parts of some challenge JSON I captured:

```json
    "speed": "bullet",
    "timeControl": {
      "type": "clock",
      "limit": 60,
      "increment": 0,
      "show": "1+0"
    },
```

```json
    "speed": "correspondence",
    "timeControl": {
      "type": "correspondence",
      "daysPerTurn": 2
    },
```

```json
    "speed": "correspondence",
    "timeControl": {
      "type": "unlimited"
    },
```
