### PR TITLE
Fix for missing secondsLeft field in unlimited games

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -381,7 +381,10 @@ def enough_time_to_queue(event, config):
     move_time = corr_cfg.get("move_time") or 60
     minimum_time = (checkin_time + move_time) * 10
     game = event["game"]
-    return not game["isMyTurn"] or game["secondsLeft"] > minimum_time
+    seconds_left = game.get("secondsLeft")
+    return (not game["isMyTurn"]
+            or seconds_left is None
+            or seconds_left > minimum_time)
 
 
 def handle_challenge(event, li, challenge_queue, challenge_config, user_profile, matchmaker):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -17,6 +17,7 @@ import sys
 import os
 import io
 import copy
+import math
 from config import load_config
 from conversation import Conversation, ChatLine
 from timer import Timer
@@ -302,7 +303,7 @@ def check_in_on_correspondence_games(pool,
 
 
 def start_low_time_games(low_time_games, active_games, max_games, pool, play_game_args):
-    low_time_games.sort(key=lambda g: g["secondsLeft"])
+    low_time_games.sort(key=lambda g: g.get("secondsLeft", math.inf))
     while low_time_games and len(active_games) < max_games:
         game_id = low_time_games.pop(0)["id"]
         active_games.add(game_id)
@@ -381,10 +382,7 @@ def enough_time_to_queue(event, config):
     move_time = corr_cfg.get("move_time") or 60
     minimum_time = (checkin_time + move_time) * 10
     game = event["game"]
-    seconds_left = game.get("secondsLeft")
-    return (not game["isMyTurn"]
-            or seconds_left is None
-            or seconds_left > minimum_time)
+    return not game["isMyTurn"] or game.get("secondsLeft", math.inf) > minimum_time
 
 
 def handle_challenge(event, li, challenge_queue, challenge_config, user_profile, matchmaker):


### PR DESCRIPTION
This bug was introduced in #594. Unlimited games don't contain a `secondsLeft` field, which causes an exception.

I made a minimal change to get the bot working again, but the correctness still hinges on the invariant that only games with a `secondsLeft` entry are put into the `low_time_games` queue, which is not obvious and might break again in the future.

It is another case of certain fields not being present on all types of games or challenges (clock/correspondence/unlimited), but not distinguishing between them in a principled way. Is there interest in a discussion on how to prevent similar issues in the future? Be it through improved testing or changes in the code, but I think the project could benefit from tackling this source of bugs.