### PR TITLE
Simplify correspondence check-ins

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -289,14 +289,14 @@ def check_in_on_correspondence_games(pool,
 
     while len(active_games) < max_games and correspondence_games_to_start > 0:
         game_id = correspondence_queue.get_nowait()
+        correspondence_games_to_start -= 1
+        correspondence_queue.task_done()
         active_games.add(game_id)
         log_proc_count("Used", active_games)
         play_game_args["game_id"] = game_id
         pool.apply_async(play_game,
                          kwds=play_game_args,
                          error_callback=game_error_handler)
-        correspondence_games_to_start -= 1
-        correspondence_queue.task_done()
 
 
 def start_low_time_games(low_time_games, active_games, max_games, pool, play_game_args):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -280,11 +280,12 @@ def check_in_on_correspondence_games(pool,
                                      max_games):
     global correspondence_games_to_start
 
-    if challenge_queue:
-        return
-    elif event["type"] == "correspondence_ping":
+    if event["type"] == "correspondence_ping":
         correspondence_games_to_start = correspondence_queue.qsize()
     elif event["type"] != "local_game_done":
+        return
+
+    if challenge_queue:
         return
 
     while len(active_games) < max_games and correspondence_games_to_start > 0:


### PR DESCRIPTION
Instead of putting special entries in the correspondence queue and interpreting them, keep a count of the maximum number of games should be started each time the correspondence check-in function in called.

After a correspondence_ping, this count is set to the number of game IDs in the queue. After a local_game_done, this number will be equal to the number of games leftover after the last check-in.

This changes the behavior of correspondence game handling. After a correspondence_ping, all correspondence games are checked, even those that were recently started. Before, the checkin_period configuration was a minimum time between game check-ins; now it's closer to a maximum.