### PR TITLE
Fine grained rate limiting

### DIFF
--- a/lichess.py
+++ b/lichess.py
@@ -129,7 +129,7 @@ class Lichess:
         return self.api_get(ENDPOINTS["game"], game_id)
 
     def upgrade_to_bot_account(self):
-        return self.api_post(ENDPOINTS, "upgrade")
+        return self.api_post(ENDPOINTS["upgrade"])
 
     def make_move(self, game_id, move):
         return self.api_post(ENDPOINTS["move"], game_id, move.move,

--- a/lichess.py
+++ b/lichess.py
@@ -76,7 +76,8 @@ class Lichess:
         
         if is_new_rate_limit(response):
             logger.warning("Rate limited. Waiting 1 minute until next request.")
-            self.rate_limit_timers[path_template] = Timer(60)
+            delay = 1 if path_template == ENDPOINTS["move"] else 60
+            self.rate_limit_timers[path_template] = Timer(delay)
         
         response.raise_for_status()
         response.encoding = "utf-8"

--- a/lichess.py
+++ b/lichess.py
@@ -75,7 +75,7 @@ class Lichess:
 
         if is_new_rate_limit(response):
             delay = 1 if endpoint_name == "move" else 60
-            self.set_rate_limit_timer(path_template, delay)
+            self.set_rate_limit_delay(path_template, delay)
 
         response.raise_for_status()
         response.encoding = "utf-8"
@@ -102,7 +102,7 @@ class Lichess:
         response = self.session.post(url, data=data, headers=headers, params=params, json=payload, timeout=2)
 
         if is_new_rate_limit(response):
-            self.set_rate_limit_delay(60)
+            self.set_rate_limit_delay(path_template, 60)
 
         if raise_for_status:
             response.raise_for_status()
@@ -124,7 +124,7 @@ class Lichess:
         return not self.rate_limit_timers[path_template].is_expired()
 
     def rate_limit_time_left(self, path_template):
-        return self.rate_limit_time_left[path_template].time_until_expiration()
+        return self.rate_limit_timers[path_template].time_until_expiration()
 
     def get_game(self, game_id):
         return self.api_get("game", game_id)

--- a/lichess.py
+++ b/lichess.py
@@ -70,15 +70,15 @@ class Lichess:
             logger.warn(f"{path_template} is rate-limited. "
                         f"Will retry in {int(self.rate_limit_time_left(path_template))} seconds.")
             return "" if get_raw_text else {}
-        
+
         url = urljoin(self.baseUrl, path_template.format(*template_args))
         response = self.session.get(url, params=params, timeout=2)
-        
+
         if is_new_rate_limit(response):
             logger.warning("Rate limited. Waiting 1 minute until next request.")
             delay = 1 if path_template == ENDPOINTS["move"] else 60
             self.rate_limit_timers[path_template] = Timer(delay)
-        
+
         response.raise_for_status()
         response.encoding = "utf-8"
         return response.text if get_raw_text else response.json()
@@ -99,19 +99,19 @@ class Lichess:
                  payload=None,
                  raise_for_status=True):
         logging.getLogger("backoff").setLevel(self.logging_level)
-        
+
         if self.is_rate_limited(path_template):
             logger.warn(f"{path_template} is rate-limited. "
                         f"Will retry in {int(self.rate_limit_time_left(path_template))} seconds.")
             return {}
-        
+
         url = urljoin(self.baseUrl, path_template.format(*template_args))
         response = self.session.post(url, data=data, headers=headers, params=params, json=payload, timeout=2)
-        
+
         if is_new_rate_limit(response):
             logger.warning("Rate limited. Waiting 1 minute until next request.")
             self.rate_limit_timers[path_template] = Timer(60)
-        
+
         if raise_for_status:
             response.raise_for_status()
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -26,7 +26,7 @@ class Matchmaking:
         self.min_wait_time = 60  # Wait 60 seconds before creating a new challenge to avoid hitting the api rate limits.
         self.challenge_id = None
         self.block_list = self.matchmaking_cfg.block_list.copy()
-        self.delay_timers = defaultdict(lambda: Timer(0))
+        self.delay_timers = defaultdict(Timer)
         delay_option = "delay_after_decline"
         self.delay_type = self.matchmaking_cfg.lookup(delay_option)
         if self.delay_type not in DelayType.__members__.values():

--- a/timer.py
+++ b/timer.py
@@ -2,7 +2,7 @@ import time
 
 
 class Timer:
-    def __init__(self, duration):
+    def __init__(self, duration=-1):
         self.duration = duration
         self.reset()
 
@@ -14,3 +14,6 @@ class Timer:
 
     def time_since_reset(self):
         return time.time() - self.starting_time
+
+    def time_until_expiration(self):
+        return max(0, self.duration - self.time_since_reset())


### PR DESCRIPTION
When a bot hits rate limits and lichess responds with a 429, use a 60-second timer on that endpoint instead of pausing the main thread of the program. This should allow game/event streams to continue mostly normally.

Will close #621.