### PR TITLE
Fix list configurations with empty values in file

### DIFF
--- a/config.py
+++ b/config.py
@@ -62,6 +62,10 @@ def set_config_default(config, *sections, key, default, force_falsey_values=Fals
 
 def change_value_to_list(config, *sections, key):
     subconfig = set_config_default(config, *sections, key=key, default=[])
+
+    if subconfig[key] is None:
+        subconfig[key] = []
+
     if not isinstance(subconfig[key], list):
         subconfig[key] = [subconfig[key]]
 


### PR DESCRIPTION
If a user has a configuration file like this:

matchmaking:
  challenge_increment:
  challenge_days:

These will be translated with the config default functions into

matchmaking:
  challenge_increment:
    - null
  challenge_days:
    - null

This commit corrects this so that null entries result in empty lists.

The force_falsey_values argument does not work because we want a single entry of 0 to be valid.