### PR TITLE
Handle move timeouts

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -21,6 +21,7 @@ from config import load_config
 from conversation import Conversation, ChatLine
 from timer import Timer
 from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError, ReadTimeout
+from asyncio.exceptions import TimeoutError as MoveTimeout
 from rich.logging import RichHandler
 from collections import defaultdict
 from http.client import RemoteDisconnected
@@ -497,7 +498,7 @@ def play_game(li,
                 prior_game = copy.deepcopy(game)
             elif u_type == "ping" and should_exit_game(board, game, prior_game, li, is_correspondence):
                 break
-        except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, StopIteration) as e:
+        except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, StopIteration, MoveTimeout) as e:
             stopped = isinstance(e, StopIteration)
             is_ongoing = game.id in (ongoing_game["gameId"] for ongoing_game in li.get_ongoing_games())
             if stopped or (not move_attempted and not is_ongoing):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -498,7 +498,13 @@ def play_game(li,
                 prior_game = copy.deepcopy(game)
             elif u_type == "ping" and should_exit_game(board, game, prior_game, li, is_correspondence):
                 break
-        except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, StopIteration, MoveTimeout) as e:
+        except (HTTPError,
+                ReadTimeout,
+                RemoteDisconnected,
+                ChunkedEncodingError,
+                ConnectionError,
+                StopIteration,
+                MoveTimeout) as e:
             stopped = isinstance(e, StopIteration)
             is_ongoing = game.id in (ongoing_game["gameId"] for ongoing_game in li.get_ongoing_games())
             if stopped or (not move_attempted and not is_ongoing):


### PR DESCRIPTION
In case engine fails to heed first move clock times, let it try again
if the game wasn't aborted, or receive the abort message.

Fixes #623 