### PR TITLE
Run fewer GitHub actions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,7 +9,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  mypy:
+    if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'Update version')"
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'Update version')"
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,4 +32,4 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
-        pytest -s
+        pytest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,4 +32,4 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
-        pytest
+        pytest -s

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'Update version')"
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -26,7 +26,7 @@ stockfish_path = f"./TEMP/sf{file_extension}"
 
 def download_sf() -> None:
     windows_or_linux = "win" if platform == "win32" else "linux"
-    base_name = f"stockfish_15_{windows_or_linux}_x64"
+    base_name = f"stockfish_14.1_{windows_or_linux}_x64"
     zip_link = f"https://stockfishchess.org/files/{base_name}.zip"
     response = requests.get(zip_link, allow_redirects=True)
     with open("./TEMP/sf_zip.zip", "wb") as file:

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -26,7 +26,7 @@ stockfish_path = f"./TEMP/sf{file_extension}"
 
 def download_sf() -> None:
     windows_or_linux = "win" if platform == "win32" else "linux"
-    base_name = f"stockfish_15.1_{windows_or_linux}_x64"
+    base_name = f"stockfish_15_{windows_or_linux}_x64"
     zip_link = f"https://stockfishchess.org/files/{base_name}.zip"
     response = requests.get(zip_link, allow_redirects=True)
     with open("./TEMP/sf_zip.zip", "wb") as file:

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -26,7 +26,7 @@ stockfish_path = f"./TEMP/sf{file_extension}"
 
 def download_sf() -> None:
     windows_or_linux = "win" if platform == "win32" else "linux"
-    base_name = f"stockfish_14.1_{windows_or_linux}_x64"
+    base_name = f"stockfish_15.1_{windows_or_linux}_x64"
     zip_link = f"https://stockfishchess.org/files/{base_name}.zip"
     response = requests.get(zip_link, allow_redirects=True)
     with open("./TEMP/sf_zip.zip", "wb") as file:
@@ -40,7 +40,7 @@ def download_sf() -> None:
 
 
 def download_lc0() -> None:
-    response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.28.2/lc0-v0.28.2-windows-cpu-dnnl.zip",
+    response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.29.0/lc0-v0.29.0-windows-cpu-dnnl.zip",
                             allow_redirects=True)
     with open("./TEMP/lc0_zip.zip", "wb") as file:
         file.write(response.content)
@@ -64,7 +64,7 @@ download_sf()
 if platform == "win32":
     download_lc0()
     download_sjeng()
-logging_level = lichess_bot.logging.INFO
+logging_level = lichess_bot.logging.DEBUG
 lichess_bot.logging_configurer(logging_level, None)
 lichess_bot.logger.info("Downloaded engines")
 


### PR DESCRIPTION
GitHub actions will now only be run when there is a PR, or the push commit message contains the text `Update version` (which it already does because we use `Update version to x.y.z.n`). This is done to avoid having to rerun as many failures. Also, update SF and LC0 versions, and use `DEBUG` instead of `INFO`.