### PR TITLE
Bug fix: Print game result value instead of enum name

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -418,7 +418,7 @@ class XBoardEngine(EngineWrapper):
         if endgame_message:
             endgame_message = " {" + endgame_message + "}"
 
-        self.engine.protocol.send_line(f"result {game_result}{endgame_message}")
+        self.engine.protocol.send_line(f"result {game_result.value}{endgame_message}")
 
     def stop(self) -> None:
         self.engine.protocol.send_line("?")


### PR DESCRIPTION
An enum in an f-string prints the enum name instead of the value. This is now fixed. Prior to using f-strings, using `+` implicitly converted to the string version.

Before: `<XBoardProtocol (pid=1396)>: << result GameEnding.WHITE_WINS {White mates}`
After: `<XBoardProtocol (pid=16780)>: << result 1-0 {White mates}`